### PR TITLE
Fix: Closing bracket on VisitClassLiteral code gen

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1,10 +1,11 @@
 package generator
 
 import (
-	"github.com/t14raptor/go-fast/ast"
-	"github.com/t14raptor/go-fast/token"
 	"strings"
 	"unicode"
+
+	"github.com/t14raptor/go-fast/ast"
+	"github.com/t14raptor/go-fast/token"
 )
 
 func Generate(node ast.VisitableNode) string {
@@ -646,10 +647,10 @@ func (g *GenVisitor) VisitClassLiteral(n *ast.ClassLiteral) {
 			g.out.WriteString(" ")
 			g.gen(e.Body.Body)
 		}
-		g.indent--
-
-		g.lineAndPad()
 	}
+	g.indent--
+
+	g.lineAndPad()
 	g.out.WriteString("}")
 }
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -649,8 +649,8 @@ func (g *GenVisitor) VisitClassLiteral(n *ast.ClassLiteral) {
 		g.indent--
 
 		g.lineAndPad()
-		g.out.WriteString("}")
 	}
+	g.out.WriteString("}")
 }
 
 func (g *GenVisitor) VisitSpreadElement(n *ast.SpreadElement) {


### PR DESCRIPTION
This fixes the VisitClassLiteral function if the body has more than one element.