### PR TITLE
Generator NewExpression complex callee

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -384,7 +384,7 @@ func (g *GenVisitor) VisitLabelledStatement(n *ast.LabelledStatement) {
 func (g *GenVisitor) VisitNewExpression(n *ast.NewExpression) {
 	g.out.WriteString("new ")
 	switch n.Callee.Expr.(type) {
-	case *ast.BinaryExpression:
+	case *ast.BinaryExpression, *ast.CallExpression, *ast.ConditionalExpression, *ast.AssignExpression, *ast.UnaryExpression:
 		g.out.WriteString("(")
 		g.gen(n.Callee.Expr)
 		g.out.WriteString(")")


### PR DESCRIPTION
### Examples for `NewExpression` with Complex Types

```javascript
// CallExpression
// Correct
new (Function.prototype.bind.apply(j, l))()

// Incorrect
new Function.prototype.bind.apply(j, l)()  // This is misinterpreted and causes an error.
```

```javascript
// UnaryExpression
// Correct
new (-obj())  // Parentheses clarify the negation operation before passing to `new`

// Incorrect
new -obj()  // This causes a syntax error because the negation is not properly grouped.
```

```javascript
// ConditionalExpression
// Correct
new (condition ? a : b)()

// Incorrect
new condition ? a : b()  // This is ambiguous and will lead to an incorrect result.
```

```javascript
// AssignmentExpression
// Correct
new (x = function() {})()

// Incorrect
new x = function() {}()  // This results in a syntax error due to incorrect precedence.
```