### PR TITLE
fix contextual "of" parsing outside for-of loops

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1787,6 +1787,44 @@ func TestForOfStatementAST(t *testing.T) {
 	}
 }
 
+func TestBareOfIdentifierParses(t *testing.T) {
+	mustParse(t, "var of = null;")
+	mustParse(t, "function of() { return 1 }")
+	mustParse(t, "({ of })")
+}
+
+func TestForOfWithIdentifierNamedOfParses(t *testing.T) {
+	p := mustParse(t, "for (let of of arr) {}")
+	forOf := firstStmt(p, 0).(*ast.ForOfStatement)
+	into := forOf.Into.Unwrap().(*ast.VariableDeclaration)
+	binding := into.List[0].Target.Unwrap().(*ast.Identifier)
+	if binding.Name != "of" {
+		t.Fatalf("loop binding = %q; want of", binding.Name)
+	}
+	if id := forOf.Source.MustIdent(); id.Name != "arr" {
+		t.Errorf("source = %q; want arr", id.Name)
+	}
+}
+
+func mustParseError(t *testing.T, code string) error {
+	_, err := parser.ParseFile(code)
+	if err == nil {
+		t.Fatalf("Expected parse error for:\n%s", code)
+	}
+	return err
+}
+
+func TestEscapedOfDoesNotCountAsForOfKeyword(t *testing.T) {
+	code := "for (const x \\u006f\\u0066 arr) {}"
+	_, err := parser.ParseFile(code)
+	if err == nil {
+		t.Fatalf("Expected parse error for:\n%s", code)
+	}
+	if !strings.Contains(err.Error(), "Unexpected") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // ===========================================================================
 // ASSIGNMENT OPERATORS
 // ===========================================================================

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1806,14 +1806,6 @@ func TestForOfWithIdentifierNamedOfParses(t *testing.T) {
 	}
 }
 
-func mustParseError(t *testing.T, code string) error {
-	_, err := parser.ParseFile(code)
-	if err == nil {
-		t.Fatalf("Expected parse error for:\n%s", code)
-	}
-	return err
-}
-
 func TestEscapedOfDoesNotCountAsForOfKeyword(t *testing.T) {
 	code := "for (const x \\u006f\\u0066 arr) {}"
 	_, err := parser.ParseFile(code)

--- a/parser/scanner/table.go
+++ b/parser/scanner/table.go
@@ -436,8 +436,6 @@ func (s *Scanner) Next() {
 
 		case 'o':
 			switch s.scanIdentifierTail() {
-			case "of":
-				s.Token.Kind = token.Of
 			default:
 				s.Token.Kind = token.Identifier
 			}

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -571,7 +571,7 @@ func (p *parser) parseForOrForInStatement() *ast.Statement {
 				if p.currentKind() == token.In {
 					p.next()
 					forIn = true
-				} else if p.currentKind() == token.Of {
+				} else if p.currentKind() == token.Of || (p.currentKind() == token.Identifier && !p.scanner.Token.HasEscape && p.currentString() == "of") {
 					p.next()
 					forOf = true
 				}
@@ -591,7 +591,7 @@ func (p *parser) parseForOrForInStatement() *ast.Statement {
 			if p.currentKind() == token.In {
 				p.next()
 				forIn = true
-			} else if p.currentKind() == token.Of {
+			} else if p.currentKind() == token.Of || (p.currentKind() == token.Identifier && !p.scanner.Token.HasEscape && p.currentString() == "of") {
 				p.next()
 				forOf = true
 			}


### PR DESCRIPTION
## Summary
- parse bare `of` as a normal identifier by default
- keep `for...of` working by recognizing `of` contextually in the `for` parser path
- reject escaped `of` as the contextual `for...of` token
- add parser tests covering both bare identifier and `for...of` cases

## Background
`go-fast` was treating `of` as a hard keyword everywhere. That is too strict for JavaScript, where `of` is contextual and should only be special in `for (... of ...)`.
Because of that, valid code like `var of = null` and `function of() {}` failed to parse. This also surfaced in a downstream deobfuscation flow when a real script used `of` as a normal identifier.

## Changes
The scanner no longer emits `token.Of` for bare `of`. Instead, `of` is scanned as an identifier by default.
To preserve existing behavior for `for...of`, the parser now accepts identifier text `"of"` only in the `parseForOrForInStatement` path. The check also requires `!HasEscape`, so escaped forms like `\\u006f\\u0066` are not treated as the contextual `for...of` token.

## Test Coverage
Added parser coverage for:
- `var of = null`
- `function of() {}`
- `({ of })`
- `for (let of of arr) {}`
- escaped `of` not being accepted as `for...of`