### PR TITLE
fix(generator): emit accessor property keywords

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -948,7 +948,12 @@ func (g *GenVisitor) VisitMemberProperty(n *ast.MemberProperty) {
 
 func (g *GenVisitor) VisitPropertyKeyed(n *ast.PropertyKeyed) {
 	if n.Kind == ast.PropertyKindGet || n.Kind == ast.PropertyKindSet {
-		g.writeString(string(n.Kind))
+		switch n.Kind {
+		case ast.PropertyKindGet:
+			g.writeString("get")
+		case ast.PropertyKindSet:
+			g.writeString("set")
+		}
 		g.writeByte(' ')
 		if n.Computed {
 			g.writeByte('[')

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -41,6 +41,13 @@ func TestMetaProperty(t *testing.T) {
 	}
 }
 
+func TestPropertyKindGetSetKeywords(t *testing.T) {
+	assertMinified(t,
+		`({get value(){return 1;},set value(next){this.next=next;}});`,
+		`({get value(){return 1;},set value(next){this.next=next;}});`,
+	)
+}
+
 func TestForInitializerForbidInRegressions(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary
- Emit `get` and `set` keywords explicitly for accessor property kinds in the generator.
- Add a regression test covering object literal getter/setter generation.

## Why
On the tagged-unions branch, `PropertyKindGet` and `PropertyKindSet` are enum values. Converting them with `string(n.Kind)` emits raw enum bytes (`\x02` / `\x03`) instead of valid JavaScript keywords, producing unparsable generated output.

## Verification
- `go test ./generator -run TestPropertyKindGetSetKeywords -count=1`
- `go test ./...`
- `git diff --check`