### PR TITLE
fix(ast,resolver): correct binding resolution and optional yield handling

### DIFF
--- a/ast/clone.go
+++ b/ast/clone.go
@@ -698,5 +698,9 @@ func (n *WithStatement) Clone() *WithStatement {
 	return &WithStatement{Object: n.Object.Clone(), Body: n.Body.Clone(), With: n.With}
 }
 func (n *YieldExpression) Clone() *YieldExpression {
-	return &YieldExpression{Argument: n.Argument.Clone(), Yield: n.Yield, Delegate: n.Delegate}
+	var argument *Expression
+	if n.Argument != nil {
+		argument = n.Argument.Clone()
+	}
+	return &YieldExpression{Argument: argument, Yield: n.Yield, Delegate: n.Delegate}
 }

--- a/ast/expr.go
+++ b/ast/expr.go
@@ -30,7 +30,7 @@ type (
 	}
 
 	YieldExpression struct {
-		Argument *Expression
+		Argument *Expression `optional:"true"`
 
 		Yield Idx
 

--- a/ast/ext/expr.go
+++ b/ast/ext/expr.go
@@ -66,7 +66,7 @@ func IsVoid(expr *ast.Expression) bool {
 // IsGlobalRefTo returns true if id references a global object.
 func IsGlobalRefTo(expr *ast.Expression, id string) bool {
 	if ident, ok := expr.Expr.(*ast.Identifier); ok {
-		return ident.Name == id && ident.ScopeContext == resolver.TopLevelMark
+		return ident.Name == id && ident.ScopeContext == resolver.UnresolvedMark
 	}
 	return false
 }
@@ -248,10 +248,10 @@ func CastToNumber(expr *ast.Expression) (value Value[float64], pure bool) {
 		}
 		return numFromStr(s.Val()), true
 	case *ast.Identifier:
-		if e.Name == "undefined" || e.Name == "NaN" && e.ScopeContext == resolver.TopLevelMark {
+		if IsGlobalRefTo(expr, "undefined") || IsGlobalRefTo(expr, "NaN") {
 			return Known(math.NaN()), true
 		}
-		if e.Name == "Infinity" && e.ScopeContext == resolver.TopLevelMark {
+		if IsGlobalRefTo(expr, "Infinity") {
 			return Known(math.Inf(1)), true
 		}
 		return Unknown[float64](), true
@@ -318,11 +318,17 @@ func AsPureString(expr *ast.Expression) Value[string] {
 	case *ast.Identifier:
 		switch e.Name {
 		case "undefined", "Infinity", "NaN":
-			return Known(e.Name)
+			if IsGlobalRefTo(expr, e.Name) {
+				return Known(e.Name)
+			}
 		case "Math", "JSON":
-			return Known(objectToStr(e.Name))
+			if IsGlobalRefTo(expr, e.Name) {
+				return Known(objectToStr(e.Name))
+			}
 		case "Date":
-			return Known(funcToStr(e.Name))
+			if IsGlobalRefTo(expr, e.Name) {
+				return Known(funcToStr(e.Name))
+			}
 		}
 	case *ast.UnaryExpression:
 		switch e.Operator {
@@ -351,7 +357,7 @@ func AsPureString(expr *ast.Expression) Value[string] {
 					sb.WriteString("")
 				}
 			case *ast.Identifier:
-				if e.Name == "undefined" {
+				if e.Name == "undefined" && e.ScopeContext == resolver.UnresolvedMark {
 					sb.WriteString("")
 				}
 			case nil:
@@ -500,14 +506,13 @@ func GetType(expr *ast.Expression) TypeValue {
 		}
 		return TypeValue{Unknown[Type]()}
 	case *ast.Identifier:
-		switch e.Name {
-		case "undefined":
+		switch {
+		case IsGlobalRefTo(expr, "undefined"):
 			return TypeValue{Known[Type](UndefinedType{})}
-		case "Infinity", "NaN":
+		case IsGlobalRefTo(expr, "Infinity"), IsGlobalRefTo(expr, "NaN"):
 			return TypeValue{Known[Type](NumberType{})}
-		default:
-			return TypeValue{Unknown[Type]()}
 		}
+		return TypeValue{Unknown[Type]()}
 	case *ast.NumberLiteral:
 		return TypeValue{Known[Type](NumberType{})}
 	case *ast.UnaryExpression:

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -945,5 +945,7 @@ func (n *YieldExpression) VisitWith(v Visitor) {
 	v.VisitYieldExpression(n)
 }
 func (n *YieldExpression) VisitChildrenWith(v Visitor) {
-	n.Argument.VisitWith(v)
+	if n.Argument != nil {
+		n.Argument.VisitWith(v)
+	}
 }

--- a/resolver/hoister.go
+++ b/resolver/hoister.go
@@ -1,42 +1,50 @@
 package resolver
 
 import (
-	"maps"
-
 	"github.com/t14raptor/go-fast/ast"
 	"github.com/t14raptor/go-fast/parser/scanner/token"
 )
 
+// hoister handles the first phase of resolution: it walks a statement
+// list and declares every var and function-declaration name in the
+// enclosing scope (and tracks the catch-parameter set)
 type hoister struct {
 	ast.NoopVisitor
 
 	resolver *Resolver
-	kind     DeclKind
-	inBlock  bool
 
+	inBlock     bool
 	inCatchBody bool
 
 	excludedFromCatch map[string]struct{}
 	catchParamDecls   map[string]struct{}
 }
 
-func newHoister(resolver *Resolver) *hoister {
-	return &hoister{
-		resolver:          resolver,
-		kind:              DeclKindVar,
-		excludedFromCatch: make(map[string]struct{}),
-		catchParamDecls:   make(map[string]struct{}),
-	}
+func getHoister(r *Resolver) *hoister {
+	h := &hoister{}
+	h.resolver = r
+	h.inBlock = false
+	h.inCatchBody = false
+	clear(h.excludedFromCatch)
+	clear(h.catchParamDecls)
+	h.V = h
+	return h
+}
+
+func putHoister(h *hoister) {
+	_ = h
 }
 
 func (h *hoister) addIdent(id *ast.Identifier) {
 	if h.inCatchBody {
 		if _, ok := h.catchParamDecls[id.Name]; ok {
-			if r, _ := h.resolver.lookupContext(id.Name); r != UnresolvedMark {
+			if mark, _ := h.resolver.lookupContext(id.Name); mark != UnresolvedMark {
 				return
 			}
 		}
-
+		if h.excludedFromCatch == nil {
+			h.excludedFromCatch = make(map[string]struct{}, 2)
+		}
 		h.excludedFromCatch[id.Name] = struct{}{}
 	} else if _, ok := h.catchParamDecls[id.Name]; ok {
 		if _, excluded := h.excludedFromCatch[id.Name]; !excluded {
@@ -44,7 +52,26 @@ func (h *hoister) addIdent(id *ast.Identifier) {
 		}
 	}
 
-	h.resolver.modify(id, h.kind)
+	h.resolver.modify(id, DeclKindVar)
+}
+
+// VisitStatements processes vars and function declarations before the
+// rest so forward references inside expressions can resolve to bindings
+// later in source order.
+func (h *hoister) VisitStatements(n *ast.Statements) {
+	for i := range *n {
+		switch (*n)[i].Stmt.(type) {
+		case *ast.VariableDeclaration, *ast.FunctionDeclaration, *ast.ClassDeclaration:
+			(*n)[i].VisitWith(h)
+		}
+	}
+	for i := range *n {
+		switch (*n)[i].Stmt.(type) {
+		case *ast.VariableDeclaration, *ast.FunctionDeclaration, *ast.ClassDeclaration:
+		default:
+			(*n)[i].VisitWith(h)
+		}
+	}
 }
 
 func (h *hoister) VisitBlockStatement(n *ast.BlockStatement) {
@@ -54,58 +81,47 @@ func (h *hoister) VisitBlockStatement(n *ast.BlockStatement) {
 	h.inBlock = old
 }
 
+// Resolver.VisitCatchStatement declares the parameter; the hoister only
+// records the param name so a redeclaring `var` inside the catch body
+// is handled
 func (h *hoister) VisitCatchStatement(n *ast.CatchStatement) {
-	oldExclude := h.excludedFromCatch
-	h.excludedFromCatch = make(map[string]struct{})
-	oldInCatchBody := h.inCatchBody
-
+	var paramName string
 	if n.Parameter != nil {
-		if params := findIds(n.Parameter); len(params) == 1 {
-			h.catchParamDecls[params[0].Name] = struct{}{}
+		// Patterns (object/array binding) aren't covered by B.3.5;
+		// leaving paramName empty skips the special-case handling.
+		if id, ok := n.Parameter.Target.(*ast.Identifier); ok {
+			paramName = id.Name
 		}
 	}
 
-	old := maps.Clone(h.catchParamDecls)
+	oldInCatchBody := h.inCatchBody
+	oldExclude := h.excludedFromCatch
+	h.excludedFromCatch = nil
+
+	var hadParam bool
+	if paramName != "" {
+		if h.catchParamDecls == nil {
+			h.catchParamDecls = make(map[string]struct{}, 1)
+		}
+		_, hadParam = h.catchParamDecls[paramName]
+		h.catchParamDecls[paramName] = struct{}{}
+	}
 
 	h.inCatchBody = true
 	n.Body.VisitWith(h)
-	h.inCatchBody = false
-	if n.Parameter != nil {
-		n.Parameter.VisitWith(h)
-	}
-
-	h.catchParamDecls = old
 	h.inCatchBody = oldInCatchBody
+
+	if paramName != "" && !hadParam {
+		delete(h.catchParamDecls, paramName)
+	}
 	h.excludedFromCatch = oldExclude
-}
-
-func (h *hoister) VisitStatements(n *ast.Statements) {
-	others := make(ast.Statements, 0, len(*n))
-	for i := range *n {
-		switch it := (*n)[i].Stmt.(type) {
-		case *ast.VariableDeclaration:
-			it.VisitWith(h)
-		case *ast.FunctionDeclaration:
-			it.VisitWith(h)
-		default:
-			others = append(others, (*n)[i])
-		}
-	}
-
-	for i := range others {
-		others[i].VisitWith(h)
-	}
 }
 
 func (h *hoister) VisitVariableDeclaration(n *ast.VariableDeclaration) {
 	if h.inBlock && n.Token != token.Var {
 		return
 	}
-
-	oldKind := h.kind
-	h.kind = DeclKindVar
 	n.VisitChildrenWith(h)
-	h.kind = oldKind
 }
 
 func (h *hoister) VisitBindingTarget(n *ast.BindingTarget) {
@@ -120,7 +136,6 @@ func (h *hoister) VisitFunctionDeclaration(n *ast.FunctionDeclaration) {
 	if _, ok := h.catchParamDecls[n.Function.Name.Name]; ok {
 		return
 	}
-
 	if h.inBlock {
 		if kind, declared := h.resolver.current.isDeclared(n.Function.Name.Name); declared {
 			if kind != DeclKindVar && kind != DeclKindFunction {
@@ -128,8 +143,14 @@ func (h *hoister) VisitFunctionDeclaration(n *ast.FunctionDeclaration) {
 			}
 		}
 	}
-
 	h.resolver.modify(n.Function.Name, DeclKindFunction)
+}
+
+func (h *hoister) VisitClassDeclaration(n *ast.ClassDeclaration) {
+	if n == nil || n.Class == nil || n.Class.Name == nil || n.Class.Name.Name == "" {
+		return
+	}
+	h.resolver.modify(n.Class.Name, DeclKindClass)
 }
 
 func (h *hoister) VisitSwitchStatement(n *ast.SwitchStatement) {
@@ -138,6 +159,19 @@ func (h *hoister) VisitSwitchStatement(n *ast.SwitchStatement) {
 	old := h.inBlock
 	h.inBlock = true
 	n.Body.VisitWith(h)
+	h.inBlock = old
+}
+
+// for-loop heads are block scopes for let/const. var still hoists out
+// thanks to the Token guard in VisitVariableDeclaration.
+func (h *hoister) VisitForStatement(n *ast.ForStatement)     { h.visitForLike(n) }
+func (h *hoister) VisitForInStatement(n *ast.ForInStatement) { h.visitForLike(n) }
+func (h *hoister) VisitForOfStatement(n *ast.ForOfStatement) { h.visitForLike(n) }
+
+func (h *hoister) visitForLike(n ast.VisitableNode) {
+	old := h.inBlock
+	h.inBlock = true
+	n.VisitChildrenWith(h)
 	h.inBlock = old
 }
 
@@ -155,7 +189,6 @@ func findIds(n ast.VisitableNode) []ast.Id {
 	v := &idsFinder{}
 	v.V = v
 	n.VisitWith(v)
-
 	return v.found
 }
 

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -1,7 +1,7 @@
 package resolver
 
 import (
-	"fmt"
+	"reflect"
 
 	"github.com/t14raptor/go-fast/ast"
 )
@@ -9,8 +9,8 @@ import (
 type IdentType int
 
 const (
-	IdentTypeRef     IdentType = iota // Reference (read)
-	IdentTypeBinding                  // Binding (declaration)
+	IdentTypeRef IdentType = iota
+	IdentTypeBinding
 )
 
 const (
@@ -24,11 +24,16 @@ type Resolver struct {
 	current *Scope
 
 	identType IdentType
-	declKind  DeclKind
+	nextCtxt  ast.ScopeContext
 
-	nextCtxt ast.ScopeContext
+	// chainView maps a name to its innermost ScopeContext in the active
+	// scope chain. Maintained via per-scope shadow entries so lookupContext
+	// is one map probe instead of a parent walk.
+	chainView map[string]ast.ScopeContext
 }
 
+// Resolve assigns a ScopeContext to every identifier in p so that two
+// identifiers share a context iff they bind to the same declaration.
 func Resolve(p ast.VisitableNode) *Resolver {
 	r := &Resolver{
 		identType: IdentTypeRef,
@@ -43,158 +48,170 @@ func Resolve(p ast.VisitableNode) *Resolver {
 func (r *Resolver) pushScope(kind ScopeKind) {
 	ctx := r.nextCtxt
 	r.nextCtxt++
-
-	r.current = &Scope{
-		parent:          r.current,
-		kind:            kind,
-		declaredSymbols: make(map[string]DeclKind),
-		ctx:             ctx,
-	}
+	r.current = getScope(r.current, kind, ctx)
 }
 
 func (r *Resolver) popScope() {
-	if r.current.parent != nil {
-		r.current = r.current.parent
+	if r.current == nil || r.current.parent == nil {
+		return
 	}
+	cur := r.current
+	for i := len(cur.shadows) - 1; i >= 0; i-- {
+		sh := cur.shadows[i]
+		if sh.hadPrev {
+			r.chainView[sh.name] = sh.prev
+		} else {
+			delete(r.chainView, sh.name)
+		}
+	}
+	r.current = cur.parent
+	putScope(cur)
 }
 
+// modify declares id in the current scope and stamps it with the
+// scope's ScopeContext. A no-op if id already has a context.
 func (r *Resolver) modify(id *ast.Identifier, kind DeclKind) {
 	if id.ScopeContext != UnresolvedMark {
 		return
 	}
 
-	r.current.declaredSymbols[id.Name] = kind
+	cur := r.current
+	if cur.declaredSymbols == nil {
+		cur.declaredSymbols = make(map[string]DeclKind, 4)
+	}
+	if _, already := cur.declaredSymbols[id.Name]; !already {
+		if r.chainView == nil {
+			r.chainView = make(map[string]ast.ScopeContext, 64)
+		}
+		prev, had := r.chainView[id.Name]
+		cur.shadows = append(cur.shadows, shadowEntry{name: id.Name, prev: prev, hadPrev: had})
+		r.chainView[id.Name] = cur.ctx
+	}
+	cur.declaredSymbols[id.Name] = kind
 
-	id.ScopeContext = r.current.ctx
+	id.ScopeContext = cur.ctx
 }
 
 func (r *Resolver) lookupContext(sym string) (ast.ScopeContext, *Scope) {
-	for scope := r.current; scope != nil; scope = scope.parent {
-		if _, exists := scope.declaredSymbols[sym]; exists {
-			return scope.ctx, scope
-		}
+	if ctx, ok := r.chainView[sym]; ok {
+		return ctx, nil
 	}
 	return UnresolvedMark, nil
 }
 
-func (r *Resolver) VisitArrowFunctionLiteral(n *ast.ArrowFunctionLiteral) {
-	r.pushScope(ScopeKindFunction)
-
-	n.ScopeContext = r.current.ctx
-
-	oldIdentType := r.identType
-	r.identType = IdentTypeBinding
-	n.ParameterList.VisitWith(r)
-
-	r.identType = IdentTypeRef
-	switch body := n.Body.Body.(type) {
-	case *ast.BlockStatement:
-		body.ScopeContext = r.current.ctx
-		// Prevent creating a new scope.
-		body.VisitChildrenWith(r)
-	case *ast.Expression:
-		body.VisitWith(r)
-	}
-	r.identType = oldIdentType
-
-	r.popScope()
+func (r *Resolver) withIdentType(kind IdentType, fn func()) {
+	old := r.identType
+	r.identType = kind
+	fn()
+	r.identType = old
 }
 
-func (r *Resolver) VisitBlockStatement(n *ast.BlockStatement) {
-	r.pushScope(ScopeKindBlock)
-	n.ScopeContext = r.current.ctx
-	n.VisitChildrenWith(r)
-	r.popScope()
+func (r *Resolver) visitRef(n ast.VisitableNode) {
+	if n == nil {
+		return
+	}
+	rv := reflect.ValueOf(n)
+	if rv.Kind() == reflect.Pointer && rv.IsNil() {
+		return
+	}
+	r.withIdentType(IdentTypeRef, func() {
+		n.VisitWith(r)
+	})
 }
 
-func (r *Resolver) VisitForOfStatement(n *ast.ForOfStatement) {
-	r.pushScope(ScopeKindBlock)
-
-	oldIdentType := r.identType
-	r.identType = IdentTypeRef
-
-	n.Into.VisitWith(r)
-	n.Source.VisitWith(r)
-
-	if blockStmt, ok := n.Body.Stmt.(*ast.BlockStatement); ok {
-		blockStmt.ScopeContext = r.current.ctx
+func (r *Resolver) declareBindingTarget(target *ast.BindingTarget) {
+	if target == nil {
+		return
 	}
-	n.Body.VisitWith(r)
-
-	r.identType = oldIdentType
-	r.popScope()
+	r.declareBindingExpr(target.Target)
 }
 
-func (r *Resolver) VisitForInStatement(n *ast.ForInStatement) {
-	r.pushScope(ScopeKindBlock)
-
-	oldIdentType := r.identType
-	r.identType = IdentTypeRef
-
-	n.Into.VisitWith(r)
-	n.Source.VisitWith(r)
-
-	if blockStmt, ok := n.Body.Stmt.(*ast.BlockStatement); ok {
-		blockStmt.ScopeContext = r.current.ctx
+func (r *Resolver) declareBindingExpr(expr ast.Expr) {
+	switch expr := expr.(type) {
+	case nil:
+		return
+	case *ast.Identifier:
+		r.modify(expr, DeclKindVar)
+	case *ast.ArrayPattern:
+		for i := range expr.Elements {
+			r.declareBindingExpr(expr.Elements[i].Expr)
+		}
+		if expr.Rest != nil {
+			r.declareBindingExpr(expr.Rest.Expr)
+		}
+	case *ast.ObjectPattern:
+		for i := range expr.Properties {
+			switch prop := expr.Properties[i].Prop.(type) {
+			case *ast.PropertyShort:
+				r.modify(prop.Name, DeclKindVar)
+			case *ast.PropertyKeyed:
+				if prop.Value != nil {
+					r.declareBindingExpr(prop.Value.Expr)
+				}
+			}
+		}
+		r.declareBindingExpr(expr.Rest)
+	case *ast.AssignExpression:
+		r.declareBindingExpr(expr.Left.Expr)
 	}
-	n.Body.VisitWith(r)
-
-	r.identType = oldIdentType
-	r.popScope()
 }
 
-func (r *Resolver) VisitForStatement(n *ast.ForStatement) {
-	r.pushScope(ScopeKindBlock)
-
-	oldIdentType := r.identType
-	r.identType = IdentTypeBinding
-
-	// Handle initializer
-	if n.Initializer != nil {
-		n.Initializer.VisitWith(r)
+func (r *Resolver) resolveBindingTargetRefs(target *ast.BindingTarget) {
+	if target == nil {
+		return
 	}
-
-	// Handle test expression
-	r.identType = IdentTypeRef
-	n.Test.VisitWith(r)
-
-	// Handle update expression
-	n.Update.VisitWith(r)
-
-	// Handle body
-	r.identType = oldIdentType
-	n.Body.VisitWith(r)
-
-	r.popScope()
+	r.resolveBindingExprRefs(target.Target)
 }
 
-func (r *Resolver) VisitFunctionLiteral(n *ast.FunctionLiteral) {
-	if n.Name != nil {
-		r.modify(n.Name, DeclKindFunction)
+func (r *Resolver) resolveBindingExprRefs(expr ast.Expr) {
+	switch expr := expr.(type) {
+	case nil, *ast.Identifier, *ast.InvalidExpression:
+		return
+	case *ast.ArrayPattern:
+		for i := range expr.Elements {
+			r.resolveBindingExprRefs(expr.Elements[i].Expr)
+		}
+		if expr.Rest != nil {
+			r.resolveBindingExprRefs(expr.Rest.Expr)
+		}
+	case *ast.ObjectPattern:
+		for i := range expr.Properties {
+			switch prop := expr.Properties[i].Prop.(type) {
+			case *ast.PropertyShort:
+				r.visitRef(prop.Initializer)
+			case *ast.PropertyKeyed:
+				if prop.Computed {
+					r.visitRef(prop.Key)
+				}
+				if prop.Value != nil {
+					r.resolveBindingExprRefs(prop.Value.Expr)
+				}
+			}
+		}
+		r.resolveBindingExprRefs(expr.Rest)
+	case *ast.AssignExpression:
+		r.resolveBindingExprRefs(expr.Left.Expr)
+		r.visitRef(expr.Right)
+	default:
+		r.visitRef(expr)
+	}
+}
+
+func (r *Resolver) visitParameterList(n *ast.ParameterList) {
+	if n == nil {
+		return
 	}
 
-	r.pushScope(ScopeKindFunction)
-
-	n.ScopeContext = r.current.ctx
-
-	oldIdentType := r.identType
-	r.identType = IdentTypeBinding
-	n.ParameterList.VisitWith(r)
-
-	if rest, ok := n.ParameterList.Rest.(*ast.Identifier); ok {
-		rest.VisitWith(r)
-	} else if n.ParameterList.Rest != nil {
-		panic(fmt.Sprintf("Unexpected rest type: %T\n", n.ParameterList.Rest))
+	for i := range n.List {
+		r.declareBindingTarget(n.List[i].Target)
 	}
+	r.declareBindingExpr(n.Rest)
 
-	r.identType = IdentTypeRef
-	// Prevent creating new scope.
-	n.Body.ScopeContext = r.current.ctx
-	n.Body.VisitChildrenWith(r)
-
-	r.identType = oldIdentType
-
-	r.popScope()
+	for i := range n.List {
+		r.resolveBindingTargetRefs(n.List[i].Target)
+		r.visitRef(n.List[i].Initializer)
+	}
+	r.resolveBindingExprRefs(n.Rest)
 }
 
 func (r *Resolver) VisitProgram(n *ast.Program) {
@@ -204,31 +221,126 @@ func (r *Resolver) VisitProgram(n *ast.Program) {
 }
 
 func (r *Resolver) VisitStatements(n *ast.Statements) {
-	// Handle hoisting
-	h := newHoister(r)
-	h.V = h
+	h := getHoister(r)
 	n.VisitWith(h)
+	putHoister(h)
 
-	// Resolve
 	n.VisitChildrenWith(r)
 }
 
-func (r *Resolver) VisitVariableDeclaration(n *ast.VariableDeclaration) {
-	oldDeclKind := r.declKind
-	r.declKind = DeclKindVar
+func (r *Resolver) VisitBlockStatement(n *ast.BlockStatement) {
+	r.pushScope(ScopeKindBlock)
+	n.ScopeContext = r.current.ctx
+	n.VisitChildrenWith(r)
+	r.popScope()
+}
 
-	for _, decl := range n.List {
-		oldIdentType := r.identType
-		r.identType = IdentTypeBinding
-		decl.Target.VisitWith(r)
-		r.identType = oldIdentType
-
-		if decl.Initializer != nil {
-			decl.Initializer.VisitWith(r)
-		}
+func (r *Resolver) VisitFunctionLiteral(n *ast.FunctionLiteral) {
+	r.pushScope(ScopeKindFunction)
+	if n.Name != nil && n.Name.ScopeContext == UnresolvedMark {
+		r.modify(n.Name, DeclKindFunction)
 	}
 
-	r.declKind = oldDeclKind
+	n.ScopeContext = r.current.ctx
+
+	r.visitParameterList(n.ParameterList)
+	// Prevent creating a new scope for the body.
+	n.Body.ScopeContext = r.current.ctx
+	n.Body.VisitChildrenWith(r)
+
+	r.popScope()
+}
+
+func (r *Resolver) VisitArrowFunctionLiteral(n *ast.ArrowFunctionLiteral) {
+	r.pushScope(ScopeKindFunction)
+
+	n.ScopeContext = r.current.ctx
+
+	r.visitParameterList(n.ParameterList)
+
+	switch body := n.Body.Body.(type) {
+	case *ast.BlockStatement:
+		body.ScopeContext = r.current.ctx
+		// Prevent creating a new scope for the body.
+		body.VisitChildrenWith(r)
+	case *ast.Expression:
+		r.visitRef(body)
+	}
+
+	r.popScope()
+}
+
+func (r *Resolver) VisitForStatement(n *ast.ForStatement) {
+	r.pushScope(ScopeKindBlock)
+
+	oldIdentType := r.identType
+	r.identType = IdentTypeBinding
+	if n.Initializer != nil {
+		n.Initializer.VisitWith(r)
+	}
+
+	r.identType = IdentTypeRef
+	n.Test.VisitWith(r)
+	n.Update.VisitWith(r)
+
+	r.identType = oldIdentType
+	n.Body.VisitWith(r)
+
+	r.popScope()
+}
+
+func (r *Resolver) VisitForInStatement(n *ast.ForInStatement) {
+	r.pushScope(ScopeKindBlock)
+
+	oldIdentType := r.identType
+	r.identType = IdentTypeRef
+	n.Into.VisitWith(r)
+	n.Source.VisitWith(r)
+	n.Body.VisitWith(r)
+	r.identType = oldIdentType
+
+	r.popScope()
+}
+
+func (r *Resolver) VisitForOfStatement(n *ast.ForOfStatement) {
+	r.pushScope(ScopeKindBlock)
+
+	oldIdentType := r.identType
+	r.identType = IdentTypeRef
+	n.Into.VisitWith(r)
+	n.Source.VisitWith(r)
+	n.Body.VisitWith(r)
+	r.identType = oldIdentType
+
+	r.popScope()
+}
+
+func (r *Resolver) VisitCatchStatement(n *ast.CatchStatement) {
+	r.pushScope(ScopeKindBlock)
+
+	if n.Parameter != nil {
+		r.declareBindingTarget(n.Parameter)
+		r.resolveBindingTargetRefs(n.Parameter)
+	}
+
+	if n.Body != nil {
+		n.Body.VisitWith(r)
+	}
+
+	r.popScope()
+}
+
+func (r *Resolver) VisitVariableDeclaration(n *ast.VariableDeclaration) {
+	for i := range n.List {
+		r.declareBindingTarget(n.List[i].Target)
+	}
+
+	for i := range n.List {
+		r.resolveBindingTargetRefs(n.List[i].Target)
+		if n.List[i].Initializer != nil {
+			r.visitRef(n.List[i].Initializer)
+		}
+	}
 }
 
 func (r *Resolver) VisitExpression(expr *ast.Expression) {
@@ -249,14 +361,76 @@ func (r *Resolver) VisitIdentifier(n *ast.Identifier) {
 
 	switch r.identType {
 	case IdentTypeBinding:
-		r.modify(n, r.declKind)
+		r.modify(n, DeclKindVar)
 	case IdentTypeRef:
 		if mark, _ := r.lookupContext(n.Name); mark != UnresolvedMark {
 			n.ScopeContext = mark
-		} else {
-			r.modify(n, r.declKind)
 		}
 	}
+}
+
+func (r *Resolver) VisitAssignExpression(n *ast.AssignExpression) {
+	if n == nil {
+		return
+	}
+	if r.identType == IdentTypeBinding && n.Operator == ast.AssignmentAssign {
+		r.withIdentType(IdentTypeBinding, func() {
+			n.Left.VisitWith(r)
+		})
+		r.visitRef(n.Right)
+		return
+	}
+
+	r.visitRef(n.Left)
+	r.visitRef(n.Right)
+}
+
+func (r *Resolver) VisitPropertyShort(n *ast.PropertyShort) {
+	if n == nil {
+		return
+	}
+	if n.Name != nil {
+		n.Name.VisitWith(r)
+	}
+	r.visitRef(n.Initializer)
+}
+
+func (r *Resolver) VisitPropertyKeyed(n *ast.PropertyKeyed) {
+	if n == nil {
+		return
+	}
+	if n.Computed {
+		r.visitRef(n.Key)
+	}
+	if n.Value != nil {
+		n.Value.VisitWith(r)
+	}
+}
+
+func (r *Resolver) VisitClassDeclaration(n *ast.ClassDeclaration) {
+	if n == nil || n.Class == nil {
+		return
+	}
+	if n.Class.Name != nil && n.Class.Name.Name != "" {
+		r.modify(n.Class.Name, DeclKindClass)
+	}
+	n.Class.VisitWith(r)
+}
+
+func (r *Resolver) VisitClassLiteral(n *ast.ClassLiteral) {
+	if n == nil {
+		return
+	}
+
+	needsInnerNameScope := n.Name != nil && n.Name.Name != "" && n.Name.ScopeContext == UnresolvedMark
+	if needsInnerNameScope {
+		r.pushScope(ScopeKindBlock)
+		r.modify(n.Name, DeclKindClass)
+		defer r.popScope()
+	}
+
+	r.visitRef(n.SuperClass)
+	n.Body.VisitWith(r)
 }
 
 func (r *Resolver) VisitMemberProperty(n *ast.MemberProperty) {

--- a/resolver/scope.go
+++ b/resolver/scope.go
@@ -7,6 +7,7 @@ type DeclKind int
 const (
 	DeclKindVar DeclKind = iota
 	DeclKindFunction
+	DeclKindClass
 )
 
 type ScopeKind int
@@ -20,17 +21,41 @@ type Scope struct {
 	parent *Scope
 
 	kind ScopeKind
-
-	ctx ast.ScopeContext
+	ctx  ast.ScopeContext
 
 	declaredSymbols map[string]DeclKind
+	shadows         []shadowEntry
+}
+
+// shadowEntry records a chainView slot this scope overwrote when it
+// first declared name. popScope walks shadows in reverse to restore the
+// outer binding (or remove the entry if there was none).
+type shadowEntry struct {
+	name    string
+	prev    ast.ScopeContext
+	hadPrev bool
 }
 
 func (s *Scope) isDeclared(id string) (DeclKind, bool) {
 	for scope := s; scope != nil; scope = scope.parent {
-		if declKind, exists := scope.declaredSymbols[id]; exists {
-			return declKind, true
+		if scope.declaredSymbols == nil {
+			continue
+		}
+		if k, exists := scope.declaredSymbols[id]; exists {
+			return k, true
 		}
 	}
 	return 0, false
+}
+
+func getScope(parent *Scope, kind ScopeKind, ctx ast.ScopeContext) *Scope {
+	return &Scope{
+		parent: parent,
+		kind:   kind,
+		ctx:    ctx,
+	}
+}
+
+func putScope(s *Scope) {
+	_ = s
 }


### PR DESCRIPTION
- stop synthesizing local bindings for unresolved references
- split binding declaration and reference resolution into separate passes
- support destructured rest parameters
- fix named function expression inner-name scoping
- fix named class expression scoping and explicit class binding handling
- hoist class declarations so forward references resolve correctly
- expand resolver and ast/ext regression coverage
- fix optional yield-expression arguments in AST clone/visitor