### PR TITLE
fix(resolver): bind function rest parameters

### DIFF
--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -182,14 +182,6 @@ func (r *Resolver) VisitFunctionLiteral(n *ast.FunctionLiteral) {
 	r.identType = IdentTypeBinding
 	n.ParameterList.VisitWith(r)
 
-	if n.ParameterList.Rest != nil {
-		if ident, ok := n.ParameterList.Rest.Ident(); ok {
-			ident.VisitWith(r)
-		} else {
-			panic(fmt.Sprintf("Unexpected rest kind: %s\n", n.ParameterList.Rest.Kind()))
-		}
-	}
-
 	r.identType = IdentTypeRef
 	// Prevent creating new scope.
 	n.Body.ScopeContext = r.current.ctx
@@ -198,6 +190,17 @@ func (r *Resolver) VisitFunctionLiteral(n *ast.FunctionLiteral) {
 	r.identType = oldIdentType
 
 	r.popScope()
+}
+
+func (r *Resolver) VisitParameterList(n *ast.ParameterList) {
+	n.List.VisitWith(r)
+	if n.Rest != nil {
+		if ident, ok := n.Rest.Ident(); ok {
+			ident.VisitWith(r)
+		} else {
+			panic(fmt.Sprintf("Unexpected rest kind: %s\n", n.Rest.Kind()))
+		}
+	}
 }
 
 func (r *Resolver) VisitProgram(n *ast.Program) {

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -1,0 +1,52 @@
+package resolver_test
+
+import (
+	"testing"
+
+	"github.com/t14raptor/go-fast/ast"
+	"github.com/t14raptor/go-fast/parser"
+	"github.com/t14raptor/go-fast/resolver"
+)
+
+type idVisitor struct {
+	ast.NoopVisitor
+	ids []ast.Id
+}
+
+func (v *idVisitor) VisitIdentifier(n *ast.Identifier) {
+	if n.Name == "P8" {
+		v.ids = append(v.ids, n.ToId())
+	}
+}
+
+func TestFunctionRestParameterCreatesFunctionScopeBinding(t *testing.T) {
+	program, err := parser.ParseFile(`function P8() { function inner(...P8) { P8.push(undefined); } P8(); }`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resolver.Resolve(program)
+
+	visitor := &idVisitor{}
+	visitor.V = visitor
+	program.VisitWith(visitor)
+
+	if len(visitor.ids) != 4 {
+		t.Fatalf("expected 4 P8 identifiers, got %d", len(visitor.ids))
+	}
+
+	outer := visitor.ids[0]
+	rest := visitor.ids[1]
+	use := visitor.ids[2]
+	outerUse := visitor.ids[3]
+
+	if rest.ScopeContext == outer.ScopeContext {
+		t.Fatalf("rest parameter resolved to outer binding: rest=%+v outer=%+v", rest, outer)
+	}
+	if use.ScopeContext != rest.ScopeContext {
+		t.Fatalf("rest parameter use resolved to wrong binding: use=%+v rest=%+v", use, rest)
+	}
+	if outerUse.ScopeContext != outer.ScopeContext {
+		t.Fatalf("outer use resolved to wrong binding: use=%+v outer=%+v", outerUse, outer)
+	}
+}


### PR DESCRIPTION
## Summary
- Bind function rest parameters while the resolver is in parameter binding mode.
- Preserve the existing panic for unexpected rest parameter AST kinds.
- Add a regression test for a rest parameter shadowing an outer function binding.

## Verification
- `go test ./...`
- `git diff --check`