### PR TITLE
generator fix

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -352,6 +352,11 @@ func (g *GenVisitor) VisitArrowFunctionLiteral(n *ast.ArrowFunctionLiteral) {
 }
 
 func (g *GenVisitor) VisitFunctionLiteral(n *ast.FunctionLiteral) {
+	wrap := g.prec > ast.PrecedenceAssign
+	if wrap {
+		g.writeByte('(')
+	}
+
 	if n.Async {
 		g.writeString("async ")
 	}
@@ -364,6 +369,10 @@ func (g *GenVisitor) VisitFunctionLiteral(n *ast.FunctionLiteral) {
 	g.gen(n.ParameterList)
 	g.space()
 	g.gen(n.Body)
+
+	if wrap {
+		g.writeByte(')')
+	}
 }
 
 func (g *GenVisitor) VisitClassLiteral(n *ast.ClassLiteral) {


### PR DESCRIPTION
generator generated invalid code for this

``
d.extend({
    processBlock: function ($, t) {
        var k = this._cipher,
            e = k.blockSize;
        ((function ($, t, k) {
            var e = this._iv;
            e ? (this._iv = void 0) : (e = this._prevBlock);
            for (var r = 0; r < k; r++) $[t + r] ^= e[r];
        }).call(this, $, t, e),
            k.encryptBlock($, t),
            (this._prevBlock = $.slice(t, t + e)));
    },
});
``

if `g.prec` is greater than `PrecedenceAssign`, it now wraps function literals