### PR TITLE
fix(parser): enforce statement termination and Unicode line breaks

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -150,6 +150,12 @@ func (p *parser) semicolon() bool {
 	return true
 }
 
+func (p *parser) requireSemicolon() {
+	if !p.semicolon() {
+		p.errorUnexpectedToken(p.currentKind())
+	}
+}
+
 func (p *parser) idxOf(offset int) ast.Idx {
 	return ast.Idx(1 + offset)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1308,6 +1308,40 @@ func TestASIReturnNewline(t *testing.T) {
 	}
 }
 
+func TestMissingRequiredSemicolonErrors(t *testing.T) {
+	for _, code := range []string{
+		`a b`,
+		`function f(){ a b }`,
+		`function f(){ x++y }`,
+		`function f(){ return 1 2 }`,
+		`function f(){ throw 1 2 }`,
+		`let a let b`,
+		`debugger debugger`,
+	} {
+		mustFail(t, code)
+	}
+}
+
+func TestUnicodeLineSeparatorsAffectASI(t *testing.T) {
+	mustFail(t, "throw\u2028x;")
+
+	p := mustParse(t, "function f(){ return\u20281; }")
+	body := bodyOf(firstStmt(p, 0))
+	if got := len(body.List); got != 2 {
+		t.Fatalf("body statements = %d; want 2 (return + expression)", got)
+	}
+	ret, ok := body.List[0].Return()
+	if !ok {
+		t.Fatalf("stmt[0] kind = %v; want Return", body.List[0].Kind())
+	}
+	if ret.Argument != nil {
+		t.Fatalf("return argument = %v; want nil", ret.Argument.Kind())
+	}
+	if !body.List[1].IsExpression() {
+		t.Fatalf("stmt[1] kind = %v; want Expression", body.List[1].Kind())
+	}
+}
+
 func TestASIReturnSameLine(t *testing.T) {
 	p := mustParse(t, "function f() { return 42 }")
 	body := bodyOf(firstStmt(p, 0))

--- a/parser/scanner/table.go
+++ b/parser/scanner/table.go
@@ -537,12 +537,12 @@ func (s *Scanner) Next() {
 			case unicodeid.IsIDStartUnicode(c):
 				s.scanIdentifierTailAfterUnicode(s.src.Offset())
 				s.Token.Kind = token.Identifier
-			case unicode.IsSpace(c):
-				s.ConsumeRune()
-				continue
 			case isLineTerminator(c):
 				s.ConsumeRune()
 				s.Token.OnNewLine = true
+				continue
+			case unicode.IsSpace(c):
+				s.ConsumeRune()
 				continue
 			default:
 				start := s.src.Offset()

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -102,7 +102,7 @@ func (p *parser) parseStatement() ast.Statement {
 		return ast.NewLabelledStmt(p.alloc.LabelledStatement(identifier, colon, statement))
 	}
 
-	p.semicolon()
+	p.requireSemicolon()
 
 	return ast.NewExpressionStmt(p.alloc.ExpressionStatement(p.alloc.Expression(expression)))
 }
@@ -397,7 +397,7 @@ func (p *parser) parseClass(declaration bool) *ast.ClassLiteral {
 
 func (p *parser) parseDebuggerStatement() ast.Statement {
 	idx := p.expect(token.Debugger)
-	p.semicolon()
+	p.requireSemicolon()
 	return ast.NewDebuggerStmt(p.alloc.DebuggerStatement(idx))
 }
 
@@ -416,7 +416,7 @@ func (p *parser) parseReturnStatement() ast.Statement {
 		node.Argument = p.alloc.Expression(p.parseExpression())
 	}
 
-	p.semicolon()
+	p.requireSemicolon()
 
 	return ast.NewReturnStmt(node)
 }
@@ -432,7 +432,7 @@ func (p *parser) parseThrowStatement() ast.Statement {
 
 	node := p.alloc.ThrowStatement(idx, p.alloc.Expression(p.parseExpression()))
 
-	p.semicolon()
+	p.requireSemicolon()
 	return ast.NewThrowStmt(node)
 }
 
@@ -666,7 +666,7 @@ func (p *parser) parseLexicalDeclaration(tok token.Token) *ast.VariableDeclarati
 
 	list := p.parseVariableDeclarationList()
 	p.ensurePatternInit(list)
-	p.semicolon()
+	p.requireSemicolon()
 
 	return p.alloc.VariableDeclaration(idx, tok, list)
 }
@@ -764,7 +764,7 @@ func (p *parser) parseBreakStatement() ast.Statement {
 			p.errorf("%s", identifier.Name)
 			return ast.NewBadStmt(p.alloc.BadStatement(idx, identifier.Idx1()))
 		}
-		p.semicolon()
+		p.requireSemicolon()
 		return ast.NewBreakStmt(p.alloc.BreakStatement(idx, identifier))
 	}
 
@@ -799,7 +799,7 @@ func (p *parser) parseContinueStatement() ast.Statement {
 		if !p.scope.inIteration {
 			goto illegal
 		}
-		p.semicolon()
+		p.requireSemicolon()
 		return ast.NewContinueStmt(p.alloc.ContinueStatement(idx, identifier))
 	}
 


### PR DESCRIPTION
## Summary

- Reject invalid same-line token leftovers after statements
- Treat Unicode line and paragraph separators as line terminators
- Add parser regression coverage for statement termination / ASI behavior

## Details

The parser previously accepted invalid programs such as:

```js
a b
return 1 2
throw 1 2
debugger debugger
let a let b
```

This updates statement termination handling so statements that require a semicolon, newline, closing brace, or EOF now reject trailing same-line tokens.

It also fixes scanner handling for:

- `\u2028`
- `\u2029`

These characters should behave as JavaScript line terminators, not generic whitespace, which matters for ASI and restricted productions like `throw`.

## Testing

```sh
go test ./...
git diff --check
```