### PR TITLE
fix(ast): correct clone generation, visitors, and source ranges

### DIFF
--- a/ast/clone.go
+++ b/ast/clone.go
@@ -5,7 +5,11 @@ func (n *ArrayLiteral) Clone() *ArrayLiteral {
 	return &ArrayLiteral{Value: *n.Value.Clone(), LeftBracket: n.LeftBracket, RightBracket: n.RightBracket}
 }
 func (n *ArrayPattern) Clone() *ArrayPattern {
-	return &ArrayPattern{Elements: *n.Elements.Clone(), Rest: n.Rest.Clone(), LeftBracket: n.LeftBracket, RightBracket: n.RightBracket}
+	var rest *Expression
+	if n.Rest != nil {
+		rest = n.Rest.Clone()
+	}
+	return &ArrayPattern{Elements: *n.Elements.Clone(), Rest: rest, LeftBracket: n.LeftBracket, RightBracket: n.RightBracket}
 }
 func (n *ArrowFunctionLiteral) Clone() *ArrowFunctionLiteral {
 	return &ArrowFunctionLiteral{ParameterList: n.ParameterList.Clone(), Body: n.Body.Clone(), ScopeContext: n.ScopeContext, Start: n.Start, Async: n.Async}
@@ -87,7 +91,7 @@ func (n *ClassStaticBlock) Clone() *ClassStaticBlock {
 	return &ClassStaticBlock{Block: n.Block.Clone(), Static: n.Static}
 }
 func (n *ComputedProperty) Clone() *ComputedProperty {
-	return &ComputedProperty{Expr: n.Expr.Clone()}
+	return &ComputedProperty{Expr: n.Expr.Clone(), LeftBracket: n.LeftBracket, RightBracket: n.RightBracket}
 }
 func (n *ConditionalExpression) Clone() *ConditionalExpression {
 	return &ConditionalExpression{Test: n.Test.Clone(), Consequent: n.Consequent.Clone(), Alternate: n.Alternate.Clone()}
@@ -136,7 +140,15 @@ func (n *ForStatement) Clone() *ForStatement {
 	if n.Initializer != nil {
 		initializer = n.Initializer.Clone()
 	}
-	return &ForStatement{Initializer: initializer, Update: n.Update.Clone(), Test: n.Test.Clone(), Body: n.Body.Clone(), For: n.For}
+	var update *Expression
+	if n.Update != nil {
+		update = n.Update.Clone()
+	}
+	var test *Expression
+	if n.Test != nil {
+		test = n.Test.Clone()
+	}
+	return &ForStatement{Initializer: initializer, Update: update, Test: test, Body: n.Body.Clone(), For: n.For}
 }
 func (n *FunctionDeclaration) Clone() *FunctionDeclaration {
 	return &FunctionDeclaration{Function: n.Function.Clone()}
@@ -146,7 +158,7 @@ func (n *FunctionLiteral) Clone() *FunctionLiteral {
 	if n.Name != nil {
 		name = n.Name.Clone()
 	}
-	return &FunctionLiteral{Name: name, ParameterList: n.ParameterList.Clone(), Body: n.Body.Clone(), ScopeContext: n.ScopeContext, Function: n.Function, Async: n.Async}
+	return &FunctionLiteral{Name: name, ParameterList: n.ParameterList.Clone(), Body: n.Body.Clone(), ScopeContext: n.ScopeContext, Function: n.Function, Async: n.Async, Generator: n.Generator}
 }
 func (n *Identifier) Clone() *Identifier {
 	return &Identifier{Name: n.Name, ScopeContext: n.ScopeContext, Idx: n.Idx}
@@ -171,7 +183,7 @@ func (n *MemberExpression) Clone() *MemberExpression {
 	return &MemberExpression{Object: n.Object.Clone(), Property: n.Property.Clone()}
 }
 func (n *MetaProperty) Clone() *MetaProperty {
-	return &MetaProperty{Meta: n.Meta.Clone(), Idx: n.Idx}
+	return &MetaProperty{Meta: n.Meta.Clone(), Property: n.Property.Clone(), Idx: n.Idx}
 }
 func (n *MethodDefinition) Clone() *MethodDefinition {
 	return &MethodDefinition{Key: n.Key.Clone(), Kind: n.Kind, Body: n.Body.Clone(), Idx: n.Idx, Computed: n.Computed, Static: n.Static}
@@ -228,7 +240,11 @@ func (n *PropertyKeyed) Clone() *PropertyKeyed {
 	return &PropertyKeyed{Key: n.Key.Clone(), Kind: n.Kind, Value: n.Value.Clone(), Computed: n.Computed}
 }
 func (n *PropertyShort) Clone() *PropertyShort {
-	return &PropertyShort{Name: n.Name.Clone(), Initializer: n.Initializer.Clone()}
+	var initializer *Expression
+	if n.Initializer != nil {
+		initializer = n.Initializer.Clone()
+	}
+	return &PropertyShort{Name: n.Name.Clone(), Initializer: initializer}
 }
 func (n *RegExpLiteral) Clone() *RegExpLiteral {
 	return &RegExpLiteral{Literal: n.Literal, Pattern: n.Pattern, Flags: n.Flags, Idx: n.Idx}
@@ -326,7 +342,11 @@ func (n *WithStatement) Clone() *WithStatement {
 	return &WithStatement{Object: n.Object.Clone(), Body: n.Body.Clone(), With: n.With}
 }
 func (n *YieldExpression) Clone() *YieldExpression {
-	return &YieldExpression{Argument: n.Argument.Clone(), Yield: n.Yield, Delegate: n.Delegate}
+	var argument *Expression
+	if n.Argument != nil {
+		argument = n.Argument.Clone()
+	}
+	return &YieldExpression{Argument: argument, Yield: n.Yield, Delegate: n.Delegate}
 }
 
 func (n *BindingTarget) Clone() *BindingTarget {

--- a/ast/expr.go
+++ b/ast/expr.go
@@ -19,7 +19,7 @@ type (
 	}
 
 	YieldExpression struct {
-		Argument *Expression
+		Argument *Expression `optional:"true"`
 
 		Yield Idx
 
@@ -41,7 +41,7 @@ type (
 
 	ArrayPattern struct {
 		Elements Expressions
-		Rest     *Expression
+		Rest     *Expression `optional:"true"`
 
 		LeftBracket  Idx
 		RightBracket Idx

--- a/ast/gen_clone.go
+++ b/ast/gen_clone.go
@@ -95,8 +95,6 @@ func main() {
 			return cmp.Compare(a, b)
 		})
 	}
-	fmt.Println(nodes)
-
 	var (
 		visitMethods []ast.Decl
 	)
@@ -272,7 +270,6 @@ func main() {
 
 	os.WriteFile("ast/clone.go", formatted, 0644)
 
-	fmt.Println(pkgs)
 }
 
 func generateUnionClone(buf *bytes.Buffer, node CloneableNodeType) {
@@ -412,13 +409,10 @@ func findCloneableNodes(f *ast.File) (types []CloneableNodeType) {
 func findStructChildren(fields []*ast.Field) (children []Child) {
 	for _, field := range fields {
 		optional := field.Tag != nil && field.Tag.Value == "`optional:\"true\"`"
-		if len(field.Names) != 0 {
-			fmt.Println(field.Names[0].Name)
-		}
 
 		switch fieldType := field.Type.(type) {
 		case *ast.SelectorExpr:
-			children = append(children, newChild(field.Names[0].Name, "", false, false, optional))
+			children = appendNamedChildren(children, field.Names, "", false, false, optional)
 		case *ast.Ident:
 			if len(field.Names) == 0 {
 				children = append(children, newChild(fieldType.Name, fieldType.Name, true, false, optional))
@@ -428,23 +422,30 @@ func findStructChildren(fields []*ast.Field) (children []Child) {
 			switch fieldType.Name {
 			case "Idx", "any", "bool", "int", "ScopeContext", "string", "PropertyKind", "Token",
 				"float64", "UnaryOperator", "AssignmentOperator", "BinaryOperator", "UpdateOperator", "LogicalOperator":
-				children = append(children, newChild(field.Names[0].Name, fieldType.Name, false, false, optional))
+				children = appendNamedChildren(children, field.Names, fieldType.Name, false, false, optional)
 			default:
-				children = append(children, newChild(field.Names[0].Name, fieldType.Name, true, false, optional))
+				children = appendNamedChildren(children, field.Names, fieldType.Name, true, false, optional)
 			}
 		case *ast.StarExpr:
 			if ident, ok := fieldType.X.(*ast.Ident); ok {
 				if ident.Name == "string" {
-					children = append(children, newChild(field.Names[0].Name, ident.Name, false, false, optional))
+					children = appendNamedChildren(children, field.Names, ident.Name, false, false, optional)
 					continue
 				}
-				children = append(children, newChild(field.Names[0].Name, ident.Name, true, true, optional))
+				children = appendNamedChildren(children, field.Names, ident.Name, true, true, optional)
 			} else {
 				// Pointer to a type from another package (e.g. *big.Int).
 				// Shallow-copy the pointer — not a cloneable AST node.
-				children = append(children, newChild(field.Names[0].Name, "", false, false, optional))
+				children = appendNamedChildren(children, field.Names, "", false, false, optional)
 			}
 		}
+	}
+	return children
+}
+
+func appendNamedChildren(children []Child, names []*ast.Ident, fieldType string, cloneable, pointer, optional bool) []Child {
+	for _, name := range names {
+		children = append(children, newChild(name.Name, fieldType, cloneable, pointer, optional))
 	}
 	return children
 }

--- a/ast/gen_visit.go
+++ b/ast/gen_visit.go
@@ -65,8 +65,6 @@ func main() {
 	slices.SortFunc(nodes, func(a, b VisitableNodeType) int {
 		return cmp.Compare(a.Name, b.Name)
 	})
-	fmt.Println(nodes)
-
 	var (
 		visitorMethods     []*ast.Field
 		noopVisitorMethods []ast.Decl
@@ -227,7 +225,6 @@ func main() {
 
 	os.WriteFile("ast/visit.go", formatted, 0644)
 
-	fmt.Println(pkgs)
 }
 
 func generateUnionVisit(buf *bytes.Buffer, node VisitableNodeType) {
@@ -303,10 +300,6 @@ func findStructChildren(fields []*ast.Field) (children []Child) {
 	for _, field := range fields {
 		optional := field.Tag != nil && field.Tag.Value == "`optional:\"true\"`"
 
-		if len(field.Names) != 0 {
-			fmt.Println(field.Names[0].Name)
-		}
-
 		switch fieldType := field.Type.(type) {
 		case *ast.Ident:
 			if len(field.Names) == 0 {
@@ -318,8 +311,9 @@ func findStructChildren(fields []*ast.Field) (children []Child) {
 			case "Idx", "any", "bool", "int", "ScopeContext", "string", "PropertyKind", "float64",
 				"UnaryOperator", "AssignmentOperator", "BinaryOperator", "UpdateOperator", "LogicalOperator":
 			default:
-				fmt.Println(fieldType.Name)
-				children = append(children, newChild(field.Names[0].Name, optional))
+				for _, name := range field.Names {
+					children = append(children, newChild(name.Name, optional))
+				}
 			}
 		case *ast.StarExpr:
 			ident, ok := fieldType.X.(*ast.Ident)
@@ -331,7 +325,9 @@ func findStructChildren(fields []*ast.Field) (children []Child) {
 			if ident.Name == "string" {
 				continue
 			}
-			children = append(children, newChild(field.Names[0].Name, optional))
+			for _, name := range field.Names {
+				children = append(children, newChild(name.Name, optional))
+			}
 		}
 	}
 	return children

--- a/ast/node.go
+++ b/ast/node.go
@@ -59,8 +59,8 @@ func (n *SuperExpression) Idx0() Idx       { return n.Idx }
 func (n *UnaryExpression) Idx0() Idx       { return n.Idx }
 func (n *UpdateExpression) Idx0() Idx      { return n.Idx }
 func (n *MetaProperty) Idx0() Idx          { return n.Idx }
-func (m *MemberExpression) Idx0() Idx      { return 0 }
-func (m *MemberExpression) Idx1() Idx      { return 0 }
+func (m *MemberExpression) Idx0() Idx      { return m.Object.Idx0() }
+func (m *MemberExpression) Idx1() Idx      { return m.Property.Idx1() }
 func (n *SpreadElement) Idx0() Idx {
 	return n.Expression.Idx0()
 }
@@ -95,28 +95,42 @@ func (n *FunctionDeclaration) Idx0() Idx { return n.Function.Idx0() }
 func (n *ClassDeclaration) Idx0() Idx    { return n.Class.Idx0() }
 func (b *VariableDeclarator) Idx0() Idx  { return b.Target.Idx0() }
 
-func (n *ComputedProperty) Idx0() Idx { return n.Expr.Idx0() }
-func (n *ComputedProperty) Idx1() Idx { return n.Expr.Idx1() }
-func (n *PropertyShort) Idx0() Idx    { return n.Name.Idx }
+func (n *ComputedProperty) Idx0() Idx {
+	if n.LeftBracket != 0 {
+		return n.LeftBracket
+	}
+	return n.Expr.Idx0()
+}
+func (n *ComputedProperty) Idx1() Idx {
+	if n.RightBracket != 0 {
+		return n.RightBracket + 1
+	}
+	return n.Expr.Idx1()
+}
+func (n *PropertyShort) Idx0() Idx { return n.Name.Idx }
 func (n *PropertyKeyed) Idx0() Idx { return n.Key.Idx0() }
 
 func (n *FieldDefinition) Idx0() Idx  { return n.Idx }
 func (n *MethodDefinition) Idx0() Idx { return n.Idx }
 func (n *ClassStaticBlock) Idx0() Idx { return n.Static }
 
-
-func (o *Optional) Idx1() Idx              { return o.Expr.Idx1() }
-func (n *OptionalChain) Idx1() Idx         { return n.Base.Idx1() }
-func (a *ArrayLiteral) Idx1() Idx          { return a.RightBracket + 1 }
-func (a *ArrayPattern) Idx1() Idx          { return a.RightBracket + 1 }
-func (a *AssignExpression) Idx1() Idx      { return a.Right.Idx1() }
-func (a *AwaitExpression) Idx1() Idx       { return a.Argument.Idx1() }
-func (n *InvalidExpression) Idx1() Idx     { return n.To }
-func (b *BinaryExpression) Idx1() Idx      { return b.Right.Idx1() }
-func (b *LogicalExpression) Idx1() Idx     { return b.Right.Idx1() }
-func (b *BooleanLiteral) Idx1() Idx        { return Idx(int(b.Idx) + 4) }
+func (o *Optional) Idx1() Idx          { return o.Expr.Idx1() }
+func (n *OptionalChain) Idx1() Idx     { return n.Base.Idx1() }
+func (a *ArrayLiteral) Idx1() Idx      { return a.RightBracket + 1 }
+func (a *ArrayPattern) Idx1() Idx      { return a.RightBracket + 1 }
+func (a *AssignExpression) Idx1() Idx  { return a.Right.Idx1() }
+func (a *AwaitExpression) Idx1() Idx   { return a.Argument.Idx1() }
+func (n *InvalidExpression) Idx1() Idx { return n.To }
+func (b *BinaryExpression) Idx1() Idx  { return b.Right.Idx1() }
+func (b *LogicalExpression) Idx1() Idx { return b.Right.Idx1() }
+func (b *BooleanLiteral) Idx1() Idx {
+	if b.Value {
+		return Idx(int(b.Idx) + 4)
+	}
+	return Idx(int(b.Idx) + 5)
+}
 func (n *CallExpression) Idx1() Idx        { return n.RightParenthesis + 1 }
-func (n *ConditionalExpression) Idx1() Idx { return n.Test.Idx1() }
+func (n *ConditionalExpression) Idx1() Idx { return n.Alternate.Idx1() }
 func (p *PrivateDotExpression) Idx1() Idx  { return p.Identifier.Idx1() }
 func (f *FunctionLiteral) Idx1() Idx       { return f.Body.Idx1() }
 func (c *ClassLiteral) Idx1() Idx          { return c.RightBrace + 1 }
@@ -181,10 +195,20 @@ func (n *PrivateIdentifier) Idx1() Idx {
 	return n.Identifier.Idx1()
 }
 
-func (n *BadStatement) Idx1() Idx        { return n.To }
-func (n *BlockStatement) Idx1() Idx      { return n.RightBrace + 1 }
-func (n *BreakStatement) Idx1() Idx      { return n.Idx }
-func (n *ContinueStatement) Idx1() Idx   { return n.Idx }
+func (n *BadStatement) Idx1() Idx   { return n.To }
+func (n *BlockStatement) Idx1() Idx { return n.RightBrace + 1 }
+func (n *BreakStatement) Idx1() Idx {
+	if n.Label != nil {
+		return n.Label.Idx1()
+	}
+	return n.Idx + 5
+}
+func (n *ContinueStatement) Idx1() Idx {
+	if n.Label != nil {
+		return n.Label.Idx1()
+	}
+	return n.Idx + 8
+}
 func (n *CaseStatement) Idx1() Idx       { return n.Consequent[len(n.Consequent)-1].Idx1() }
 func (n *CatchStatement) Idx1() Idx      { return n.Body.Idx1() }
 func (n *DebuggerStatement) Idx1() Idx   { return n.Debugger + 8 }
@@ -200,11 +224,16 @@ func (n *IfStatement) Idx1() Idx {
 	}
 	return n.Consequent.Idx1()
 }
-func (n *LabelledStatement) Idx1() Idx { return n.Colon + 1 }
+func (n *LabelledStatement) Idx1() Idx { return n.Statement.Idx1() }
 func (n *Program) Idx1() Idx           { return n.Body[len(n.Body)-1].Idx1() }
-func (n *ReturnStatement) Idx1() Idx   { return n.Return + 6 }
-func (n *SwitchStatement) Idx1() Idx   { return n.Body[len(n.Body)-1].Idx1() }
-func (n *ThrowStatement) Idx1() Idx    { return n.Argument.Idx1() }
+func (n *ReturnStatement) Idx1() Idx {
+	if n.Argument != nil {
+		return n.Argument.Idx1()
+	}
+	return n.Return + 6
+}
+func (n *SwitchStatement) Idx1() Idx { return n.Body[len(n.Body)-1].Idx1() }
+func (n *ThrowStatement) Idx1() Idx  { return n.Argument.Idx1() }
 func (n *TryStatement) Idx1() Idx {
 	if n.Finally != nil {
 		return n.Finally.Idx1()
@@ -256,4 +285,5 @@ func (y *YieldExpression) Idx1() Idx {
 	}
 	return y.Yield + 5
 }
+
 // Expression.Idx0/Idx1 and Statement.Idx0/Idx1 are generated in union_gen.go.

--- a/ast/prop.go
+++ b/ast/prop.go
@@ -5,7 +5,7 @@ import "unsafe"
 type PropertyKind uint8
 
 const (
-	PropertyKindValue  PropertyKind = iota + 1
+	PropertyKindValue PropertyKind = iota + 1
 	PropertyKindGet
 	PropertyKindSet
 	PropertyKindMethod
@@ -23,7 +23,7 @@ type (
 
 	PropertyShort struct {
 		Name        *Identifier
-		Initializer *Expression
+		Initializer *Expression `optional:"true"`
 	}
 
 	PropertyKeyed struct {
@@ -35,5 +35,8 @@ type (
 
 	ComputedProperty struct {
 		Expr *Expression
+
+		LeftBracket  Idx
+		RightBracket Idx
 	}
 )

--- a/ast/stmt.go
+++ b/ast/stmt.go
@@ -135,8 +135,8 @@ type (
 
 	ForStatement struct {
 		Initializer *ForLoopInitializer `optional:"true"`
-		Update      *Expression
-		Test        *Expression
+		Update      *Expression         `optional:"true"`
+		Test        *Expression         `optional:"true"`
 		Body        *Statement
 
 		For Idx

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -362,7 +362,9 @@ func (n *ArrayPattern) VisitWith(v Visitor) {
 }
 func (n *ArrayPattern) VisitChildrenWith(v Visitor) {
 	n.Elements.VisitWith(v)
-	n.Rest.VisitWith(v)
+	if n.Rest != nil {
+		n.Rest.VisitWith(v)
+	}
 }
 func (n *ArrowFunctionLiteral) VisitWith(v Visitor) {
 	v.VisitArrowFunctionLiteral(n)
@@ -570,8 +572,12 @@ func (n *ForStatement) VisitChildrenWith(v Visitor) {
 	if n.Initializer != nil {
 		n.Initializer.VisitWith(v)
 	}
-	n.Update.VisitWith(v)
-	n.Test.VisitWith(v)
+	if n.Update != nil {
+		n.Update.VisitWith(v)
+	}
+	if n.Test != nil {
+		n.Test.VisitWith(v)
+	}
 	n.Body.VisitWith(v)
 }
 func (n *FunctionDeclaration) VisitWith(v Visitor) {
@@ -636,6 +642,7 @@ func (n *MetaProperty) VisitWith(v Visitor) {
 }
 func (n *MetaProperty) VisitChildrenWith(v Visitor) {
 	n.Meta.VisitWith(v)
+	n.Property.VisitWith(v)
 }
 func (n *MethodDefinition) VisitWith(v Visitor) {
 	v.VisitMethodDefinition(n)
@@ -736,7 +743,9 @@ func (n *PropertyShort) VisitWith(v Visitor) {
 }
 func (n *PropertyShort) VisitChildrenWith(v Visitor) {
 	n.Name.VisitWith(v)
-	n.Initializer.VisitWith(v)
+	if n.Initializer != nil {
+		n.Initializer.VisitWith(v)
+	}
 }
 func (n *RegExpLiteral) VisitWith(v Visitor) {
 	v.VisitRegExpLiteral(n)
@@ -887,7 +896,9 @@ func (n *YieldExpression) VisitWith(v Visitor) {
 	v.VisitYieldExpression(n)
 }
 func (n *YieldExpression) VisitChildrenWith(v Visitor) {
-	n.Argument.VisitWith(v)
+	if n.Argument != nil {
+		n.Argument.VisitWith(v)
+	}
 }
 
 func (n *BindingTarget) VisitWith(v Visitor) {

--- a/parser/alloc.go
+++ b/parser/alloc.go
@@ -410,9 +410,9 @@ func (a *nodeAllocator) MemberProperty(mp ast.MemberProperty) *ast.MemberPropert
 	return n
 }
 
-func (a *nodeAllocator) ComputedProperty(expr *ast.Expression) *ast.ComputedProperty {
+func (a *nodeAllocator) ComputedProperty(left ast.Idx, expr *ast.Expression, right ast.Idx) *ast.ComputedProperty {
 	n := a.compProp.make()
-	*n = ast.ComputedProperty{Expr: expr}
+	*n = ast.ComputedProperty{Expr: expr, LeftBracket: left, RightBracket: right}
 	return n
 }
 

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -544,12 +544,12 @@ func (p *parser) parseDotMember(left *ast.Expression) ast.Expression {
 }
 
 func (p *parser) parseBracketMember(left *ast.Expression) ast.Expression {
-	p.expect(token.LeftBracket)
+	leftBracket := p.expect(token.LeftBracket)
 	member := p.alloc.Expression(p.parseExpression())
-	p.expect(token.RightBracket)
+	rightBracket := p.expect(token.RightBracket)
 	return ast.NewMemberExpr(p.alloc.MemberExpression(
 		left,
-		p.alloc.MemberProperty(ast.NewComputedMemProp(p.alloc.ComputedProperty(member))),
+		p.alloc.MemberProperty(ast.NewComputedMemProp(p.alloc.ComputedProperty(leftBracket, member, rightBracket))),
 	))
 }
 


### PR DESCRIPTION
## Summary

- Fix generated clone/visitor handling for optional and multi-name fields
- Correct several AST `Idx0` / `Idx1` source ranges
- Preserve computed property bracket positions in the AST

## Details

This fixes generated AST traversal/clone issues where fields could be skipped or nil optional child fields could panic during cloning.

Notable fixes:

- Optional child fields are handled safely by generated clone/visitor code
- Multi-name struct fields are handled correctly, e.g.
  - `Async, Generator bool`
  - `Meta, Property *Identifier`
  - `LeftBracket, RightBracket Idx`
- Refactored repeated field-name handling in the clone generator
- Removed unnecessary helper allocation in AST generators
- Removed debug generator prints

This also fixes source ranges for several nodes, including:

- member expressions
- computed properties
- conditional expressions
- `false`
- labels
- `return`
- `break`
- `continue`

Computed properties now store bracket positions:

```go
LeftBracket  Idx
RightBracket Idx
```

That allows spans like `obj[foo /* comment */]` to include the closing bracket instead of ending at the inner expression.

## Testing

```sh
go test ./...
git diff --check
```