### PR TITLE
fix(ast/ext): account for declaration initializer side effects

### DIFF
--- a/ast/ext/stmt.go
+++ b/ast/ext/stmt.go
@@ -75,7 +75,18 @@ func MayHaveSideEffectsStmt(stmt ast.Statement) bool {
 		// TODO: Check in_strict mode like swc
 	case ast.StmtVarDecl:
 		s := stmt.MustVarDecl()
-		return s.Token == token.Var
+		if s.Token == token.Var {
+			return true
+		}
+		for _, decl := range s.List {
+			if decl.Target.IsPattern() {
+				return true
+			}
+			if decl.Initializer != nil && MayHaveSideEffects(decl.Initializer) {
+				return true
+			}
+		}
+		return false
 	case ast.StmtExpression:
 		s := stmt.MustExpression()
 		return MayHaveSideEffects(s.Expression)

--- a/ast/ext/stmt_test.go
+++ b/ast/ext/stmt_test.go
@@ -1,0 +1,37 @@
+package ext_test
+
+import (
+	"testing"
+
+	"github.com/t14raptor/go-fast/ast/ext"
+	"github.com/t14raptor/go-fast/parser"
+)
+
+func TestMayHaveSideEffectsStmtChecksLexicalInitializers(t *testing.T) {
+	program, err := parser.ParseFile("let x = foo();")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !ext.MayHaveSideEffectsStmt(program.Body[0]) {
+		t.Fatal("let initializer call should be side-effectful")
+	}
+
+	program, err = parser.ParseFile("const x = 1;")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ext.MayHaveSideEffectsStmt(program.Body[0]) {
+		t.Fatal("pure const initializer should not be side-effectful")
+	}
+
+	program, err = parser.ParseFile("const {[foo()]: x} = {}; ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !ext.MayHaveSideEffectsStmt(program.Body[0]) {
+		t.Fatal("destructuring patterns should be treated as side-effectful")
+	}
+}


### PR DESCRIPTION
## Summary

- Detect side effects in `let` / `const` declaration initializers
- Treat destructuring declaration targets conservatively
- Add side-effect analysis regression tests

## Details

`MayHaveSideEffectsStmt` previously missed side effects in lexical declaration initializers, for example:

```js
let x = foo()
const y = bar()
```

Those calls should make the declaration side-effectful.

This also treats destructuring declarations conservatively as side-effectful. That may miss some optimization opportunities, but it avoids incorrectly removing declarations whose pattern evaluation could be observable.

## Testing

```sh
go test ./...
git diff --check
```