### PR TITLE
fix(resolver): correct binding and catch parameter scopes

### DIFF
--- a/resolver/binding.go
+++ b/resolver/binding.go
@@ -1,0 +1,219 @@
+package resolver
+
+import "github.com/t14raptor/go-fast/ast"
+
+func (r *Resolver) bindDeclarator(n ast.VariableDeclarator) {
+	r.declareBindingTarget(n.Target)
+	r.resolveBindingTargetReferences(n.Target)
+	if n.Initializer != nil {
+		n.Initializer.VisitWith(r)
+	}
+}
+
+func (r *Resolver) declareBindingTarget(n *ast.BindingTarget) {
+	forEachBindingIdentInTarget(n, func(id *ast.Identifier) {
+		r.modify(id, r.declKind)
+	})
+}
+
+func (r *Resolver) declareBindingExpression(n *ast.Expression) {
+	forEachBindingIdentInExpression(n, func(id *ast.Identifier) {
+		r.modify(id, r.declKind)
+	})
+}
+
+func (r *Resolver) resolveBindingTargetReferences(n *ast.BindingTarget) {
+	if n == nil || n.IsNone() {
+		return
+	}
+
+	if pattern, ok := n.ArrPat(); ok {
+		r.resolveArrayPatternBindingReferences(pattern)
+		return
+	}
+
+	if pattern, ok := n.ObjPat(); ok {
+		r.resolveObjectPatternBindingReferences(pattern)
+		return
+	}
+
+	if _, ok := n.Ident(); ok {
+		return
+	}
+
+	n.VisitChildrenWith(r)
+}
+
+func (r *Resolver) resolveBindingExpressionReferences(n *ast.Expression) {
+	if n == nil || n.IsNone() {
+		return
+	}
+
+	if pattern, ok := n.ArrPat(); ok {
+		r.resolveArrayPatternBindingReferences(pattern)
+		return
+	}
+
+	if pattern, ok := n.ObjPat(); ok {
+		r.resolveObjectPatternBindingReferences(pattern)
+		return
+	}
+
+	if assign, ok := n.Assign(); ok {
+		r.resolveBindingExpressionReferences(assign.Left)
+		assign.Right.VisitWith(r)
+		return
+	}
+
+	if keyed, ok := n.Keyed(); ok {
+		if keyed.Computed {
+			keyed.Key.VisitWith(r)
+		}
+		r.resolveBindingExpressionReferences(keyed.Value)
+		return
+	}
+
+	if short, ok := n.Short(); ok {
+		if short.Initializer != nil {
+			short.Initializer.VisitWith(r)
+		}
+		return
+	}
+
+	if spread, ok := n.Spread(); ok {
+		r.resolveBindingExpressionReferences(spread.Expression)
+	}
+}
+
+func (r *Resolver) resolveArrayPatternBindingReferences(n *ast.ArrayPattern) {
+	for i := range n.Elements {
+		r.resolveBindingExpressionReferences(&n.Elements[i])
+	}
+	r.resolveBindingExpressionReferences(n.Rest)
+}
+
+func (r *Resolver) resolveObjectPatternBindingReferences(n *ast.ObjectPattern) {
+	for i := range n.Properties {
+		r.resolvePropertyBindingReferences(&n.Properties[i])
+	}
+	r.resolveBindingExpressionReferences(n.Rest)
+}
+
+func (r *Resolver) resolvePropertyBindingReferences(n *ast.Property) {
+	if n == nil || n.IsNone() {
+		return
+	}
+
+	if keyed, ok := n.Keyed(); ok {
+		if keyed.Computed {
+			keyed.Key.VisitWith(r)
+		}
+		r.resolveBindingExpressionReferences(keyed.Value)
+		return
+	}
+
+	if short, ok := n.Short(); ok {
+		if short.Initializer != nil {
+			short.Initializer.VisitWith(r)
+		}
+		return
+	}
+
+	if spread, ok := n.Spread(); ok {
+		r.resolveBindingExpressionReferences(spread.Expression)
+	}
+}
+
+func forEachBindingIdentInTarget(n *ast.BindingTarget, visit func(*ast.Identifier)) {
+	if n == nil || n.IsNone() {
+		return
+	}
+
+	if ident, ok := n.Ident(); ok {
+		visit(ident)
+		return
+	}
+
+	if pattern, ok := n.ArrPat(); ok {
+		forEachBindingIdentInArrayPattern(pattern, visit)
+		return
+	}
+
+	if pattern, ok := n.ObjPat(); ok {
+		forEachBindingIdentInObjectPattern(pattern, visit)
+	}
+}
+
+func forEachBindingIdentInExpression(n *ast.Expression, visit func(*ast.Identifier)) {
+	if n == nil || n.IsNone() {
+		return
+	}
+
+	if ident, ok := n.Ident(); ok {
+		visit(ident)
+		return
+	}
+
+	if pattern, ok := n.ArrPat(); ok {
+		forEachBindingIdentInArrayPattern(pattern, visit)
+		return
+	}
+
+	if pattern, ok := n.ObjPat(); ok {
+		forEachBindingIdentInObjectPattern(pattern, visit)
+		return
+	}
+
+	if assign, ok := n.Assign(); ok {
+		forEachBindingIdentInExpression(assign.Left, visit)
+		return
+	}
+
+	if keyed, ok := n.Keyed(); ok {
+		forEachBindingIdentInExpression(keyed.Value, visit)
+		return
+	}
+
+	if short, ok := n.Short(); ok {
+		visit(short.Name)
+		return
+	}
+
+	if spread, ok := n.Spread(); ok {
+		forEachBindingIdentInExpression(spread.Expression, visit)
+	}
+}
+
+func forEachBindingIdentInArrayPattern(n *ast.ArrayPattern, visit func(*ast.Identifier)) {
+	for i := range n.Elements {
+		forEachBindingIdentInExpression(&n.Elements[i], visit)
+	}
+	forEachBindingIdentInExpression(n.Rest, visit)
+}
+
+func forEachBindingIdentInObjectPattern(n *ast.ObjectPattern, visit func(*ast.Identifier)) {
+	for i := range n.Properties {
+		forEachBindingIdentInProperty(&n.Properties[i], visit)
+	}
+	forEachBindingIdentInExpression(n.Rest, visit)
+}
+
+func forEachBindingIdentInProperty(n *ast.Property, visit func(*ast.Identifier)) {
+	if n == nil || n.IsNone() {
+		return
+	}
+
+	if keyed, ok := n.Keyed(); ok {
+		forEachBindingIdentInExpression(keyed.Value, visit)
+		return
+	}
+
+	if short, ok := n.Short(); ok {
+		visit(short.Name)
+		return
+	}
+
+	if spread, ok := n.Spread(); ok {
+		forEachBindingIdentInExpression(spread.Expression, visit)
+	}
+}

--- a/resolver/hoister.go
+++ b/resolver/hoister.go
@@ -1,8 +1,6 @@
 package resolver
 
 import (
-	"maps"
-
 	"github.com/t14raptor/go-fast/ast"
 	"github.com/t14raptor/go-fast/parser/scanner/token"
 )
@@ -22,10 +20,8 @@ type hoister struct {
 
 func newHoister(resolver *Resolver) *hoister {
 	return &hoister{
-		resolver:          resolver,
-		kind:              DeclKindVar,
-		excludedFromCatch: make(map[string]struct{}),
-		catchParamDecls:   make(map[string]struct{}),
+		resolver: resolver,
+		kind:     DeclKindVar,
 	}
 }
 
@@ -33,10 +29,14 @@ func (h *hoister) addIdent(id *ast.Identifier) {
 	if h.inCatchBody {
 		if _, ok := h.catchParamDecls[id.Name]; ok {
 			if r, _ := h.resolver.lookupContext(id.Name); r != UnresolvedMark {
+				id.ScopeContext = r
 				return
 			}
 		}
 
+		if h.excludedFromCatch == nil {
+			h.excludedFromCatch = make(map[string]struct{})
+		}
 		h.excludedFromCatch[id.Name] = struct{}{}
 	} else if _, ok := h.catchParamDecls[id.Name]; ok {
 		if _, excluded := h.excludedFromCatch[id.Name]; !excluded {
@@ -56,25 +56,31 @@ func (h *hoister) VisitBlockStatement(n *ast.BlockStatement) {
 
 func (h *hoister) VisitCatchStatement(n *ast.CatchStatement) {
 	oldExclude := h.excludedFromCatch
-	h.excludedFromCatch = make(map[string]struct{})
+	h.excludedFromCatch = nil
 	oldInCatchBody := h.inCatchBody
 
+	var paramName string
 	if n.Parameter != nil {
-		if params := findIds(n.Parameter); len(params) == 1 {
-			h.catchParamDecls[params[0].Name] = struct{}{}
+		if ident, ok := n.Parameter.Ident(); ok {
+			paramName = ident.Name
 		}
 	}
 
-	old := maps.Clone(h.catchParamDecls)
+	var hadParam bool
+	if paramName != "" {
+		if h.catchParamDecls == nil {
+			h.catchParamDecls = make(map[string]struct{})
+		}
+		_, hadParam = h.catchParamDecls[paramName]
+		h.catchParamDecls[paramName] = struct{}{}
+	}
 
 	h.inCatchBody = true
 	n.Body.VisitWith(h)
-	h.inCatchBody = false
-	if n.Parameter != nil {
-		n.Parameter.VisitWith(h)
-	}
 
-	h.catchParamDecls = old
+	if paramName != "" && !hadParam {
+		delete(h.catchParamDecls, paramName)
+	}
 	h.inCatchBody = oldInCatchBody
 	h.excludedFromCatch = oldExclude
 }
@@ -109,11 +115,9 @@ func (h *hoister) VisitVariableDeclaration(n *ast.VariableDeclaration) {
 }
 
 func (h *hoister) VisitBindingTarget(n *ast.BindingTarget) {
-	if ident, ok := n.Ident(); ok {
+	forEachBindingIdentInTarget(n, func(ident *ast.Identifier) {
 		h.addIdent(ident)
-		return
-	}
-	n.VisitChildrenWith(h)
+	})
 }
 
 func (h *hoister) VisitFunctionDeclaration(n *ast.FunctionDeclaration) {
@@ -144,23 +148,3 @@ func (h *hoister) VisitSwitchStatement(n *ast.SwitchStatement) {
 func (h *hoister) VisitArrowFunctionLiteral(*ast.ArrowFunctionLiteral) {}
 func (h *hoister) VisitExpression(*ast.Expression)                     {}
 func (h *hoister) VisitFunctionLiteral(*ast.FunctionLiteral)           {}
-
-type idsFinder struct {
-	ast.NoopVisitor
-
-	found []ast.Id
-}
-
-func findIds(n ast.VisitableNode) []ast.Id {
-	v := &idsFinder{}
-	v.V = v
-	n.VisitWith(v)
-
-	return v.found
-}
-
-func (v *idsFinder) VisitExpression(*ast.Expression) {}
-
-func (v *idsFinder) VisitIdentifier(n *ast.Identifier) {
-	v.found = append(v.found, n.ToId())
-}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -1,10 +1,6 @@
 package resolver
 
-import (
-	"fmt"
-
-	"github.com/t14raptor/go-fast/ast"
-)
+import "github.com/t14raptor/go-fast/ast"
 
 type IdentType int
 
@@ -182,14 +178,6 @@ func (r *Resolver) VisitFunctionLiteral(n *ast.FunctionLiteral) {
 	r.identType = IdentTypeBinding
 	n.ParameterList.VisitWith(r)
 
-	if n.ParameterList.Rest != nil {
-		if ident, ok := n.ParameterList.Rest.Ident(); ok {
-			ident.VisitWith(r)
-		} else {
-			panic(fmt.Sprintf("Unexpected rest kind: %s\n", n.ParameterList.Rest.Kind()))
-		}
-	}
-
 	r.identType = IdentTypeRef
 	// Prevent creating new scope.
 	n.Body.ScopeContext = r.current.ctx
@@ -197,6 +185,32 @@ func (r *Resolver) VisitFunctionLiteral(n *ast.FunctionLiteral) {
 
 	r.identType = oldIdentType
 
+	r.popScope()
+}
+
+func (r *Resolver) VisitParameterList(n *ast.ParameterList) {
+	for i := range n.List {
+		r.declareBindingTarget(n.List[i].Target)
+	}
+	r.declareBindingExpression(n.Rest)
+
+	for i := range n.List {
+		r.resolveBindingTargetReferences(n.List[i].Target)
+		if n.List[i].Initializer != nil {
+			n.List[i].Initializer.VisitWith(r)
+		}
+	}
+	r.resolveBindingExpressionReferences(n.Rest)
+}
+
+func (r *Resolver) VisitCatchStatement(n *ast.CatchStatement) {
+	r.pushScope(ScopeKindBlock)
+	if n.Parameter != nil {
+		r.declareBindingTarget(n.Parameter)
+		r.resolveBindingTargetReferences(n.Parameter)
+	}
+	n.Body.ScopeContext = r.current.ctx
+	n.Body.VisitChildrenWith(r)
 	r.popScope()
 }
 
@@ -221,17 +235,19 @@ func (r *Resolver) VisitVariableDeclaration(n *ast.VariableDeclaration) {
 	r.declKind = DeclKindVar
 
 	for _, decl := range n.List {
-		oldIdentType := r.identType
-		r.identType = IdentTypeBinding
-		decl.Target.VisitWith(r)
-		r.identType = oldIdentType
-
-		if decl.Initializer != nil {
-			decl.Initializer.VisitWith(r)
-		}
+		r.bindDeclarator(decl)
 	}
 
 	r.declKind = oldDeclKind
+}
+
+func (r *Resolver) VisitBindingTarget(n *ast.BindingTarget) {
+	if r.identType == IdentTypeBinding {
+		r.declareBindingTarget(n)
+		r.resolveBindingTargetReferences(n)
+		return
+	}
+	n.VisitChildrenWith(r)
 }
 
 func (r *Resolver) VisitExpression(expr *ast.Expression) {

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -1,0 +1,294 @@
+package resolver_test
+
+import (
+	"testing"
+
+	"github.com/t14raptor/go-fast/ast"
+	"github.com/t14raptor/go-fast/parser"
+	"github.com/t14raptor/go-fast/resolver"
+)
+
+type idVisitor struct {
+	ast.NoopVisitor
+	name string
+	ids  []ast.Id
+}
+
+func idsForName(t *testing.T, src, name string) []ast.Id {
+	t.Helper()
+
+	program, err := parser.ParseFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resolver.Resolve(program)
+
+	visitor := &idVisitor{name: name}
+	visitor.V = visitor
+	program.VisitWith(visitor)
+	return visitor.ids
+}
+
+func (v *idVisitor) VisitIdentifier(n *ast.Identifier) {
+	if n.Name == v.name {
+		v.ids = append(v.ids, n.ToId())
+	}
+}
+
+func requireIDCount(t *testing.T, ids []ast.Id, want int) {
+	t.Helper()
+	if len(ids) != want {
+		t.Fatalf("expected %d identifiers, got %d: %+v", want, len(ids), ids)
+	}
+}
+
+func TestFunctionRestParameterCreatesFunctionScopeBinding(t *testing.T) {
+	ids := idsForName(t, `function P8() { function inner(...P8) { P8.push(undefined); } P8(); }`, "P8")
+	requireIDCount(t, ids, 4)
+
+	outer := ids[0]
+	rest := ids[1]
+	use := ids[2]
+	outerUse := ids[3]
+
+	if rest.ScopeContext == outer.ScopeContext {
+		t.Fatalf("rest parameter resolved to outer binding: rest=%+v outer=%+v", rest, outer)
+	}
+	if use.ScopeContext != rest.ScopeContext {
+		t.Fatalf("rest parameter use resolved to wrong binding: use=%+v rest=%+v", use, rest)
+	}
+	if outerUse.ScopeContext != outer.ScopeContext {
+		t.Fatalf("outer use resolved to wrong binding: use=%+v outer=%+v", outerUse, outer)
+	}
+}
+
+func TestArrowRestParameterCreatesFunctionScopeBinding(t *testing.T) {
+	ids := idsForName(t, `let rest; const fn = (...rest) => rest; rest;`, "rest")
+	requireIDCount(t, ids, 4)
+
+	outer := ids[0]
+	rest := ids[1]
+	use := ids[2]
+	outerUse := ids[3]
+
+	if rest.ScopeContext == outer.ScopeContext {
+		t.Fatalf("arrow rest parameter resolved to outer binding: rest=%+v outer=%+v", rest, outer)
+	}
+	if use.ScopeContext != rest.ScopeContext {
+		t.Fatalf("arrow rest use resolved to wrong binding: use=%+v rest=%+v", use, rest)
+	}
+	if outerUse.ScopeContext != outer.ScopeContext {
+		t.Fatalf("outer rest use resolved to wrong binding: use=%+v outer=%+v", outerUse, outer)
+	}
+}
+
+func TestDestructuredParameterCreatesFunctionScopeBinding(t *testing.T) {
+	xs := idsForName(t, `let x; const fn = ([x]) => x; x;`, "x")
+	requireIDCount(t, xs, 4)
+
+	outer := xs[0]
+	param := xs[1]
+	use := xs[2]
+	outerUse := xs[3]
+
+	if param.ScopeContext == outer.ScopeContext {
+		t.Fatalf("destructured parameter resolved to outer binding: param=%+v outer=%+v", param, outer)
+	}
+	if use.ScopeContext != param.ScopeContext {
+		t.Fatalf("destructured parameter use resolved to wrong binding: use=%+v param=%+v", use, param)
+	}
+	if outerUse.ScopeContext != outer.ScopeContext {
+		t.Fatalf("outer destructured-name use resolved to wrong binding: use=%+v outer=%+v", outerUse, outer)
+	}
+
+	ys := idsForName(t, `let y; const fn = ({a: y}) => y; y;`, "y")
+	requireIDCount(t, ys, 4)
+
+	outer = ys[0]
+	param = ys[1]
+	use = ys[2]
+	outerUse = ys[3]
+
+	if param.ScopeContext == outer.ScopeContext {
+		t.Fatalf("object destructured parameter resolved to outer binding: param=%+v outer=%+v", param, outer)
+	}
+	if use.ScopeContext != param.ScopeContext {
+		t.Fatalf("object destructured parameter use resolved to wrong binding: use=%+v param=%+v", use, param)
+	}
+	if outerUse.ScopeContext != outer.ScopeContext {
+		t.Fatalf("outer object destructured-name use resolved to wrong binding: use=%+v outer=%+v", outerUse, outer)
+	}
+}
+
+func TestDestructuredParameterComputedKeyAndDefaultScopes(t *testing.T) {
+	xs := idsForName(t, `let k, x; const fn = ({[k]: x}) => x; k; x;`, "x")
+	requireIDCount(t, xs, 4)
+
+	outerX := xs[0]
+	paramX := xs[1]
+	bodyX := xs[2]
+	outerUseX := xs[3]
+
+	if paramX.ScopeContext == outerX.ScopeContext {
+		t.Fatalf("computed-key destructured binding resolved to outer scope: param=%+v outer=%+v", paramX, outerX)
+	}
+	if bodyX.ScopeContext != paramX.ScopeContext {
+		t.Fatalf("computed-key body use resolved to wrong binding: use=%+v param=%+v", bodyX, paramX)
+	}
+	if outerUseX.ScopeContext != outerX.ScopeContext {
+		t.Fatalf("outer computed-key binding use resolved to wrong binding: use=%+v outer=%+v", outerUseX, outerX)
+	}
+
+	ks := idsForName(t, `let k, x; const fn = ({[k]: x}) => x; k; x;`, "k")
+	requireIDCount(t, ks, 3)
+
+	outerK := ks[0]
+	computedK := ks[1]
+	outerUseK := ks[2]
+
+	if computedK.ScopeContext != outerK.ScopeContext {
+		t.Fatalf("computed key should resolve as reference to outer binding: key=%+v outer=%+v", computedK, outerK)
+	}
+	if outerUseK.ScopeContext != outerK.ScopeContext {
+		t.Fatalf("outer computed key use resolved to wrong binding: use=%+v outer=%+v", outerUseK, outerK)
+	}
+
+	ys := idsForName(t, `let x, y; const fn = ({x = y}) => x; y;`, "y")
+	requireIDCount(t, ys, 3)
+
+	outerY := ys[0]
+	defaultY := ys[1]
+	outerUseY := ys[2]
+
+	if defaultY.ScopeContext != outerY.ScopeContext {
+		t.Fatalf("default initializer should resolve as reference to outer binding: init=%+v outer=%+v", defaultY, outerY)
+	}
+	if outerUseY.ScopeContext != outerY.ScopeContext {
+		t.Fatalf("outer default-name use resolved to wrong binding: use=%+v outer=%+v", outerUseY, outerY)
+	}
+}
+
+func TestParameterDefaultCanReferenceLaterParameterBinding(t *testing.T) {
+	ids := idsForName(t, `let b; function f(a = b, b) { return b; } b;`, "b")
+	requireIDCount(t, ids, 5)
+
+	outer := ids[0]
+	defaultUse := ids[1]
+	param := ids[2]
+	bodyUse := ids[3]
+	outerUse := ids[4]
+
+	if param.ScopeContext == outer.ScopeContext {
+		t.Fatalf("later parameter resolved to outer binding: param=%+v outer=%+v", param, outer)
+	}
+	if defaultUse.ScopeContext != param.ScopeContext {
+		t.Fatalf("default initializer resolved to wrong binding: use=%+v param=%+v", defaultUse, param)
+	}
+	if bodyUse.ScopeContext != param.ScopeContext {
+		t.Fatalf("body use resolved to wrong binding: use=%+v param=%+v", bodyUse, param)
+	}
+	if outerUse.ScopeContext != outer.ScopeContext {
+		t.Fatalf("outer later-parameter-name use resolved to wrong binding: use=%+v outer=%+v", outerUse, outer)
+	}
+}
+
+func TestCatchParameterCreatesCatchScopeBinding(t *testing.T) {
+	ids := idsForName(t, `let e; try { throw 1; } catch (e) { e; } e;`, "e")
+	requireIDCount(t, ids, 4)
+
+	outer := ids[0]
+	param := ids[1]
+	bodyUse := ids[2]
+	outerUse := ids[3]
+
+	if param.ScopeContext == outer.ScopeContext {
+		t.Fatalf("catch parameter resolved to outer binding: param=%+v outer=%+v", param, outer)
+	}
+	if bodyUse.ScopeContext != param.ScopeContext {
+		t.Fatalf("catch body use resolved to wrong binding: use=%+v param=%+v", bodyUse, param)
+	}
+	if outerUse.ScopeContext != outer.ScopeContext {
+		t.Fatalf("outer catch-name use resolved to wrong binding: use=%+v outer=%+v", outerUse, outer)
+	}
+}
+
+func TestCatchParameterDoesNotLeakIntoLaterHoisting(t *testing.T) {
+	ids := idsForName(t, `let e; function f() { try { throw 1; } catch (e) {} e; var e; } e;`, "e")
+	requireIDCount(t, ids, 5)
+
+	outer := ids[0]
+	catchParam := ids[1]
+	preUse := ids[2]
+	varBinding := ids[3]
+	outerUse := ids[4]
+
+	if catchParam.ScopeContext == outer.ScopeContext {
+		t.Fatalf("catch parameter resolved to outer binding: param=%+v outer=%+v", catchParam, outer)
+	}
+	if varBinding.ScopeContext == outer.ScopeContext || varBinding.ScopeContext == catchParam.ScopeContext {
+		t.Fatalf("var binding resolved to wrong scope: var=%+v outer=%+v catch=%+v", varBinding, outer, catchParam)
+	}
+	if preUse.ScopeContext != varBinding.ScopeContext {
+		t.Fatalf("post-catch pre-var use was not hoisted to var binding: use=%+v var=%+v", preUse, varBinding)
+	}
+	if outerUse.ScopeContext != outer.ScopeContext {
+		t.Fatalf("outer catch-name use resolved to wrong binding: use=%+v outer=%+v", outerUse, outer)
+	}
+}
+
+func TestCatchBodyVarWithExistingOuterVarResolvesToOuterVar(t *testing.T) {
+	ids := idsForName(t, `function f() { var e; try { throw 1; } catch (e) { var e; } e; }`, "e")
+	requireIDCount(t, ids, 4)
+
+	functionVar := ids[0]
+	catchParam := ids[1]
+	catchVar := ids[2]
+	postCatchUse := ids[3]
+
+	if catchParam.ScopeContext == functionVar.ScopeContext {
+		t.Fatalf("catch parameter resolved to function var: param=%+v var=%+v", catchParam, functionVar)
+	}
+	if catchVar.ScopeContext != functionVar.ScopeContext {
+		t.Fatalf("catch body var resolved outside function var: catchVar=%+v functionVar=%+v", catchVar, functionVar)
+	}
+	if postCatchUse.ScopeContext != functionVar.ScopeContext {
+		t.Fatalf("post-catch use resolved outside function var: use=%+v functionVar=%+v", postCatchUse, functionVar)
+	}
+}
+
+func TestDestructuredCatchParameterDoesNotHoistOutsideCatch(t *testing.T) {
+	ids := idsForName(t, `let e; try { throw {}; } catch ({e}) { e; } e;`, "e")
+	requireIDCount(t, ids, 4)
+
+	outer := ids[0]
+	param := ids[1]
+	bodyUse := ids[2]
+	outerUse := ids[3]
+
+	if param.ScopeContext == outer.ScopeContext {
+		t.Fatalf("destructured catch parameter resolved to outer binding: param=%+v outer=%+v", param, outer)
+	}
+	if bodyUse.ScopeContext != param.ScopeContext {
+		t.Fatalf("destructured catch body use resolved to wrong binding: use=%+v param=%+v", bodyUse, param)
+	}
+	if outerUse.ScopeContext != outer.ScopeContext {
+		t.Fatalf("outer destructured catch-name use resolved to wrong binding: use=%+v outer=%+v", outerUse, outer)
+	}
+}
+
+func TestDestructuredVarDeclarationIsHoisted(t *testing.T) {
+	ids := idsForName(t, `var x; function f(o) { x; var {x} = o; }`, "x")
+	requireIDCount(t, ids, 3)
+
+	outer := ids[0]
+	preUse := ids[1]
+	binding := ids[2]
+
+	if binding.ScopeContext == outer.ScopeContext {
+		t.Fatalf("destructured var binding resolved to outer scope: binding=%+v outer=%+v", binding, outer)
+	}
+	if preUse.ScopeContext != binding.ScopeContext {
+		t.Fatalf("pre-declaration var use was not hoisted: use=%+v binding=%+v", preUse, binding)
+	}
+}


### PR DESCRIPTION
## Summary

- Bind rest and destructured parameters correctly
- Resolve parameter default initializers against parameter scope
- Fix destructured `var` hoisting
- Fix catch parameter scope and catch-body `var` handling
- Add resolver regression tests

## Details

This adds focused binding-pattern traversal for places where generic AST visiting cannot distinguish binding identifiers from reference expressions inside the same pattern.

Fixes include:

- function rest parameters resolving as bindings instead of references
- arrow rest parameters resolving as bindings
- array/object destructured parameters
- computed destructuring keys resolving as references
- destructuring default initializers resolving as references
- parameter defaults seeing later parameter bindings
- destructured `var` declarations being hoisted correctly
- catch parameters getting a catch-local scope
- destructured catch parameters not leaking outside the catch block
- catch body `var` declarations resolving correctly when an outer var already exists

The hoister catch handling was also adjusted to avoid leaking catch parameter state after leaving the catch block.

A follow-up PR will build on this to address function/class/loop resolver scopes.

## Testing

```sh
go test ./...
git diff --check
```