### PR TITLE
fix(generator): preserve token boundaries in minified output

### DIFF
--- a/generator/binary_expr.go
+++ b/generator/binary_expr.go
@@ -103,7 +103,11 @@ descend:
 		} else {
 			g.space()
 			g.writeString(e.op)
-			g.space()
+			if g.opts.Minified && needsBinaryOperatorSeparator(e.op, e.right) {
+				g.writeByte(' ')
+			} else {
+				g.space()
+			}
 		}
 
 		g.genExpr(e.right, e.rightPrec, e.ctx)
@@ -112,4 +116,57 @@ descend:
 			g.writeByte(')')
 		}
 	}
+}
+
+func needsBinaryOperatorSeparator(op string, right *ast.Expression) bool {
+	switch op {
+	case "+":
+		if unary, ok := right.Unary(); ok && unary.Operator == ast.UnaryPlus {
+			return true
+		}
+		if update, ok := right.Update(); ok && !update.Postfix && update.Operator == ast.UpdateIncrement {
+			return true
+		}
+	case "-":
+		if unary, ok := right.Unary(); ok && unary.Operator == ast.UnaryNegation {
+			return true
+		}
+		if update, ok := right.Update(); ok && !update.Postfix && update.Operator == ast.UpdateDecrement {
+			return true
+		}
+	case "/":
+		return startsWithRegExpLiteral(right)
+	}
+	return false
+}
+
+func startsWithRegExpLiteral(expr *ast.Expression) bool {
+	if expr == nil {
+		return false
+	}
+	if expr.IsRegExpLit() {
+		return true
+	}
+	if member, ok := expr.Member(); ok {
+		return startsWithRegExpLiteral(member.Object)
+	}
+	if call, ok := expr.Call(); ok {
+		return startsWithRegExpLiteral(call.Callee)
+	}
+	if newExpr, ok := expr.New(); ok {
+		return startsWithRegExpLiteral(newExpr.Callee)
+	}
+	if tmpl, ok := expr.TmplLit(); ok && tmpl.Tag != nil {
+		return startsWithRegExpLiteral(tmpl.Tag)
+	}
+	if priv, ok := expr.PrivDot(); ok {
+		return startsWithRegExpLiteral(priv.Left)
+	}
+	if opt, ok := expr.Optional(); ok {
+		return startsWithRegExpLiteral(opt.Expr)
+	}
+	if chain, ok := expr.OptChain(); ok {
+		return startsWithRegExpLiteral(chain.Base)
+	}
+	return false
 }

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -205,3 +205,12 @@ func TestSequenceExpressionInNewExpression(t *testing.T) {
 		})
 	}
 }
+
+func TestMinifiedOperatorTokenBoundaries(t *testing.T) {
+	assertMinified(t, `a + ++b;`, `a+ ++b;`)
+	assertMinified(t, `a - --b;`, `a- --b;`)
+	assertMinified(t, `a + +b;`, `a+ +b;`)
+	assertMinified(t, `a - -b;`, `a- -b;`)
+	assertMinified(t, `x = a / /b/.source;`, `x=a/ /b/.source;`)
+	assertMinified(t, `x = a / /b/();`, `x=a/ /b/();`)
+}


### PR DESCRIPTION
## Summary

- Prevent minified binary expressions from merging into different tokens
- Preserve required spacing around `+`, `-`, and `/` edge cases
- Add generator regression tests for token-boundary cases

## Details

The minifier could previously emit ambiguous or invalid token sequences.

Examples:

```js
a + ++b
a - --b
a + +b
a - -b
x = a / /b/.source
x = a / /b/()
```

Without careful spacing, these can become different syntax, such as:

```js
a+++b
a---b
x=a//b/.source
```

This adds targeted separator handling for binary operators when the right-hand expression starts with a token that would otherwise merge with the operator.

## Testing

```sh
go test ./...
git diff --check
```