### PR TITLE
fix(resolver): correct function class and loop scopes

### DIFF
--- a/resolver/hoister.go
+++ b/resolver/hoister.go
@@ -135,6 +135,41 @@ func (h *hoister) VisitPattern(n *ast.Pattern) {
 	n.VisitWith(&h.binder)
 }
 
+func (h *hoister) VisitForStatement(n *ast.ForStatement) {
+	if n.Initializer != nil {
+		if decl, ok := n.Initializer.VarDecl(); ok && decl.Kind == ast.VarKindVar {
+			decl.VisitWith(h)
+		}
+	}
+
+	old := h.inBlock
+	h.inBlock = true
+	n.Body.VisitWith(h)
+	h.inBlock = old
+}
+
+func (h *hoister) VisitForInStatement(n *ast.ForInStatement) {
+	if decl, ok := n.Into.VarDecl(); ok && decl.Kind == ast.VarKindVar {
+		decl.VisitWith(h)
+	}
+
+	old := h.inBlock
+	h.inBlock = true
+	n.Body.VisitWith(h)
+	h.inBlock = old
+}
+
+func (h *hoister) VisitForOfStatement(n *ast.ForOfStatement) {
+	if decl, ok := n.Into.VarDecl(); ok && decl.Kind == ast.VarKindVar {
+		decl.VisitWith(h)
+	}
+
+	old := h.inBlock
+	h.inBlock = true
+	n.Body.VisitWith(h)
+	h.inBlock = old
+}
+
 func (h *hoister) VisitFunctionDeclaration(n *ast.FunctionDeclaration) {
 	if _, ok := h.catchParamDecls[n.Function.Name.Name]; ok {
 		return

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -162,7 +162,7 @@ func (r *resolver) VisitForStatement(n *ast.ForStatement) {
 
 func (r *resolver) VisitFunctionLiteral(n *ast.FunctionLiteral) {
 	r.pushScope(scopeKindFunction)
-	if n.Name != nil && n.Name.ScopeContext == ast.UnresolvedContext {
+	if n.Name != nil {
 		r.modify(n.Name, declKindFunction)
 	}
 

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -144,10 +144,14 @@ func (r *resolver) VisitForStatement(n *ast.ForStatement) {
 
 	// Handle test expression
 	r.identType = identTypeRef
-	n.Test.VisitWith(r)
+	if n.Test != nil {
+		n.Test.VisitWith(r)
+	}
 
 	// Handle update expression
-	n.Update.VisitWith(r)
+	if n.Update != nil {
+		n.Update.VisitWith(r)
+	}
 
 	// Handle body
 	r.identType = oldIdentType
@@ -157,11 +161,10 @@ func (r *resolver) VisitForStatement(n *ast.ForStatement) {
 }
 
 func (r *resolver) VisitFunctionLiteral(n *ast.FunctionLiteral) {
-	if n.Name != nil {
+	r.pushScope(scopeKindFunction)
+	if n.Name != nil && n.Name.ScopeContext == ast.UnresolvedContext {
 		r.modify(n.Name, declKindFunction)
 	}
-
-	r.pushScope(scopeKindFunction)
 
 	n.ScopeContext = r.current.ctx
 
@@ -177,6 +180,30 @@ func (r *resolver) VisitFunctionLiteral(n *ast.FunctionLiteral) {
 	r.identType = oldIdentType
 
 	r.popScope()
+}
+
+func (r *resolver) VisitClassDeclaration(n *ast.ClassDeclaration) {
+	if n.Class.Name != nil {
+		r.modify(n.Class.Name, declKindClass)
+	}
+	n.Class.VisitWith(r)
+}
+
+func (r *resolver) VisitClassLiteral(n *ast.ClassLiteral) {
+	needsInnerNameScope := n.Name != nil && n.Name.ScopeContext == ast.UnresolvedContext
+	if needsInnerNameScope {
+		r.pushScope(scopeKindBlock)
+		r.modify(n.Name, declKindClass)
+	}
+
+	if n.SuperClass != nil {
+		n.SuperClass.VisitWith(r)
+	}
+	n.Body.VisitWith(r)
+
+	if needsInnerNameScope {
+		r.popScope()
+	}
 }
 
 func (r *resolver) VisitParameterList(n *ast.ParameterList) {

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -292,3 +292,119 @@ func TestDestructuredVarDeclarationIsHoisted(t *testing.T) {
 		t.Fatalf("pre-declaration var use was not hoisted: use=%+v binding=%+v", preUse, binding)
 	}
 }
+
+func TestNamedFunctionExpressionNameIsFunctionLocal(t *testing.T) {
+	ids := idsForName(t, `let g; const fn = function g() { return g; }; g;`, "g")
+	requireIDCount(t, ids, 4)
+
+	outer := ids[0]
+	name := ids[1]
+	selfUse := ids[2]
+	outerUse := ids[3]
+
+	if name.ScopeContext == outer.ScopeContext {
+		t.Fatalf("function expression name resolved to outer binding: name=%+v outer=%+v", name, outer)
+	}
+	if selfUse.ScopeContext != name.ScopeContext {
+		t.Fatalf("function self-reference resolved to wrong binding: use=%+v name=%+v", selfUse, name)
+	}
+	if outerUse.ScopeContext != outer.ScopeContext {
+		t.Fatalf("outer function-name use resolved to wrong binding: use=%+v outer=%+v", outerUse, outer)
+	}
+}
+
+func TestClassDeclarationCreatesBlockScopeBinding(t *testing.T) {
+	ids := idsForName(t, `let C; { class C {} C; } C;`, "C")
+	requireIDCount(t, ids, 4)
+
+	outer := ids[0]
+	className := ids[1]
+	blockUse := ids[2]
+	outerUse := ids[3]
+
+	if className.ScopeContext == outer.ScopeContext {
+		t.Fatalf("class declaration resolved to outer binding: class=%+v outer=%+v", className, outer)
+	}
+	if blockUse.ScopeContext != className.ScopeContext {
+		t.Fatalf("block class use resolved to wrong binding: use=%+v class=%+v", blockUse, className)
+	}
+	if outerUse.ScopeContext != outer.ScopeContext {
+		t.Fatalf("outer class-name use resolved to wrong binding: use=%+v outer=%+v", outerUse, outer)
+	}
+}
+
+func TestNamedClassExpressionNameIsClassLocal(t *testing.T) {
+	ids := idsForName(t, `let C; const X = class C { m() { return C; } }; C;`, "C")
+	requireIDCount(t, ids, 4)
+
+	outer := ids[0]
+	name := ids[1]
+	selfUse := ids[2]
+	outerUse := ids[3]
+
+	if name.ScopeContext == outer.ScopeContext {
+		t.Fatalf("class expression name resolved to outer binding: name=%+v outer=%+v", name, outer)
+	}
+	if selfUse.ScopeContext != name.ScopeContext {
+		t.Fatalf("class self-reference resolved to wrong binding: use=%+v name=%+v", selfUse, name)
+	}
+	if outerUse.ScopeContext != outer.ScopeContext {
+		t.Fatalf("outer class-name use resolved to wrong binding: use=%+v outer=%+v", outerUse, outer)
+	}
+}
+
+func TestForLetInitializerDoesNotHoistToFunctionScope(t *testing.T) {
+	ids := idsForName(t, `let i; function f() { for (let i = 0; i < 1; i++) {} return i; }`, "i")
+	requireIDCount(t, ids, 5)
+
+	outer := ids[0]
+	loopBinding := ids[1]
+	testUse := ids[2]
+	updateUse := ids[3]
+	returnUse := ids[4]
+
+	if loopBinding.ScopeContext == outer.ScopeContext {
+		t.Fatalf("loop let binding resolved to outer scope: loop=%+v outer=%+v", loopBinding, outer)
+	}
+	if testUse.ScopeContext != loopBinding.ScopeContext || updateUse.ScopeContext != loopBinding.ScopeContext {
+		t.Fatalf("loop uses resolved outside loop binding: test=%+v update=%+v loop=%+v", testUse, updateUse, loopBinding)
+	}
+	if returnUse.ScopeContext != outer.ScopeContext {
+		t.Fatalf("post-loop use resolved to loop/function scope, want outer: use=%+v outer=%+v", returnUse, outer)
+	}
+}
+
+func TestResolveForStatementOptionalParts(t *testing.T) {
+	for _, src := range []string{
+		`for (;;) {}`,
+		`for (; x;) {}`,
+		`for (;; i++) {}`,
+	} {
+		program, err := parser.Parse(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resolver.Resolve(program)
+	}
+}
+
+func TestForInOfLetInitializerDoesNotHoistToFunctionScope(t *testing.T) {
+	for _, src := range []string{
+		`let x; function f(obj) { for (let x in obj) {} return x; }`,
+		`let x; function f(arr) { for (let x of arr) {} return x; }`,
+	} {
+		ids := idsForName(t, src, "x")
+		requireIDCount(t, ids, 3)
+
+		outer := ids[0]
+		loopBinding := ids[1]
+		returnUse := ids[2]
+
+		if loopBinding.ScopeContext == outer.ScopeContext {
+			t.Fatalf("loop lexical binding resolved to outer scope in %q: loop=%+v outer=%+v", src, loopBinding, outer)
+		}
+		if returnUse.ScopeContext != outer.ScopeContext {
+			t.Fatalf("post-loop use resolved to loop/function scope in %q: use=%+v outer=%+v", src, returnUse, outer)
+		}
+	}
+}

--- a/resolver/scope.go
+++ b/resolver/scope.go
@@ -16,6 +16,7 @@ const (
 
 	declKindVar      declKind = 0
 	declKindFunction declKind = 1
+	declKindClass    declKind = 2
 
 	identTypeRef     identType = 0 // Reference (read)
 	identTypeBinding identType = 1 // Binding (declaration)


### PR DESCRIPTION
## Summary

- Fix named function expression scope
- Fix class declaration and class expression name scopes
- Fix `for` / `for-in` / `for-of` lexical scoping
- Add nil guards for optional `for` parts

## Details

This builds on the resolver binding/catch fixes that are now present on `tagged-unions`.

Fixes include:

- named function expressions binding their name in the function-local scope
- class declarations creating block-scope bindings
- named class expressions binding their class name locally
- `for (let ...)` not leaking into function scope
- `for (let x in obj)` and `for (let x of arr)` not leaking into function scope
- `for (;;)`, `for (; test;)`, and `for (;; update)` no longer panicking during resolve

The branch was rebuilt against the current `tagged-unions` branch after the upstream AST/resolver refactors.

## Testing

```sh
go test ./...
git diff --check
```