### PR TITLE
fix(generator): emit class heritage, super, generators, and templates

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -433,11 +433,11 @@ func (g *GenVisitor) VisitClassLiteral(n *ast.ClassLiteral) {
 	g.writeByte('{')
 
 	g.indent++
-	for i := range n.Body {
+	for _, element := range n.Body {
 		g.lineAndPad()
-		switch n.Body[i].Kind() {
+		switch element.Kind() {
 		case ast.ClassElemMethodDef:
-			e := n.Body[i].MustMethodDef()
+			e := element.MustMethodDef()
 			if e.Static {
 				g.writeString("static ")
 			}
@@ -460,7 +460,7 @@ func (g *GenVisitor) VisitClassLiteral(n *ast.ClassLiteral) {
 			g.genPropertyName(e.Key)
 			g.genMethodBody(e.Body)
 		case ast.ClassElemFieldDef:
-			e := n.Body[i].MustFieldDef()
+			e := element.MustFieldDef()
 			if e.Static {
 				g.writeString("static ")
 			}
@@ -473,7 +473,7 @@ func (g *GenVisitor) VisitClassLiteral(n *ast.ClassLiteral) {
 			}
 			g.writeByte(';')
 		case ast.ClassElemStaticBlock:
-			e := n.Body[i].MustStaticBlock()
+			e := element.MustStaticBlock()
 			g.writeString("static")
 			g.space()
 			g.gen(e.Block)

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -406,11 +406,13 @@ func (g *GenVisitor) VisitFunctionLiteral(n *ast.FunctionLiteral) {
 	if n.Async {
 		g.writeString("async ")
 	}
+	g.writeString("function")
+	if n.Generator {
+		g.writeByte('*')
+	}
 	if n.Name != nil {
-		g.writeString("function ")
+		g.writeByte(' ')
 		g.gen(n.Name)
-	} else {
-		g.writeString("function")
 	}
 	g.gen(n.ParameterList)
 	g.space()
@@ -423,15 +425,19 @@ func (g *GenVisitor) VisitClassLiteral(n *ast.ClassLiteral) {
 		g.writeByte(' ')
 		g.gen(n.Name)
 	}
+	if n.SuperClass != nil {
+		g.writeString(" extends ")
+		g.genExpr(n.SuperClass, ast.PrecedenceAssign, 0)
+	}
 	g.space()
 	g.writeByte('{')
 
 	g.indent++
-	for _, element := range n.Body {
+	for i := range n.Body {
 		g.lineAndPad()
-		switch element.Kind() {
+		switch n.Body[i].Kind() {
 		case ast.ClassElemMethodDef:
-			e := element.MustMethodDef()
+			e := n.Body[i].MustMethodDef()
 			if e.Static {
 				g.writeString("static ")
 			}
@@ -454,7 +460,7 @@ func (g *GenVisitor) VisitClassLiteral(n *ast.ClassLiteral) {
 			g.genPropertyName(e.Key)
 			g.genMethodBody(e.Body)
 		case ast.ClassElemFieldDef:
-			e := element.MustFieldDef()
+			e := n.Body[i].MustFieldDef()
 			if e.Static {
 				g.writeString("static ")
 			}
@@ -467,7 +473,7 @@ func (g *GenVisitor) VisitClassLiteral(n *ast.ClassLiteral) {
 			}
 			g.writeByte(';')
 		case ast.ClassElemStaticBlock:
-			e := element.MustStaticBlock()
+			e := n.Body[i].MustStaticBlock()
 			g.writeString("static")
 			g.space()
 			g.gen(e.Block)
@@ -492,6 +498,10 @@ func (g *GenVisitor) VisitPrivateIdentifier(n *ast.PrivateIdentifier) {
 
 func (g *GenVisitor) VisitThisExpression(n *ast.ThisExpression) {
 	g.writeString("this")
+}
+
+func (g *GenVisitor) VisitSuperExpression(n *ast.SuperExpression) {
+	g.writeString("super")
 }
 
 func (g *GenVisitor) VisitNullLiteral(n *ast.NullLiteral) {
@@ -551,9 +561,12 @@ func (g *GenVisitor) VisitRegExpLiteral(n *ast.RegExpLiteral) {
 }
 
 func (g *GenVisitor) VisitTemplateLiteral(n *ast.TemplateLiteral) {
+	if n.Tag != nil {
+		g.genAccessHead(n.Tag, ast.PrecedenceCall, false)
+	}
 	g.writeByte('`')
 	for i, e := range n.Elements {
-		g.writeString(e.Parsed)
+		g.writeString(e.Literal)
 		if i < len(n.Expressions) {
 			g.writeString("${")
 			g.genExpr(&n.Expressions[i], ast.PrecedenceLowest, 0)

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -295,3 +295,41 @@ func TestLiteralMemberAndCallBasesMinified(t *testing.T) {
 func TestComputedMemberSequenceMinified(t *testing.T) {
 	assertMinified(t, `a[(b,c)]; a?.[(b,c)];`, `a[(b,c)];a?.[(b,c)];`)
 }
+
+func TestSuperAndClassFeaturesMinified(t *testing.T) {
+	assertMinified(t,
+		`class A extends B { constructor(){ super(); super.x; } }`,
+		`class A extends B{constructor(){super();super.x;}}`,
+	)
+	assertMinified(t, `class A { x = 1; static y; static { foo(); } }`, `class A{x=1;static y;static{foo();}}`)
+	assertMinified(t,
+		`class A { async m(){ await x; } *g(){ yield 1; } [a+b](){} }`,
+		`class A{async m(){await x;}*g(){yield 1;}[a+b](){}}`,
+	)
+	assertMinified(t, `class A extends (a, b) {}`, `class A extends (a,b){}`)
+	assertMinified(t, `class A { [(a,b)](){} [(a,b)] = 1; }`, `class A{[(a,b)](){}[(a,b)]=1;}`)
+}
+
+func TestGeneratorFunctionsAndObjectMethodsMinified(t *testing.T) {
+	assertMinified(t, `function* g(){ yield 1; }`, `function* g(){yield 1;}`)
+	assertMinified(t, `async function* g(){ yield 1; }`, `async function* g(){yield 1;}`)
+	assertMinified(t,
+		`({ m(){ return super.x; }, *g(){ yield 1; } });`,
+		`({m(){return super.x;},*g(){yield 1;}});`,
+	)
+}
+
+func TestTemplateLiteralMinified(t *testing.T) {
+	assertMinified(t, "tag`x${y}`;", "tag`x${y}`;")
+	assertMinified(t, "`\\${x}`;", "`\\${x}`;")
+	assertMinified(t, "`\\n`;", "`\\n`;")
+	assertMinified(t, "(function(){})`x`;", "(function(){})`x`;")
+	assertMinified(t, "(class {})`x`;", "(class {})`x`;")
+	assertMinified(t, "({})`x`;", "({})`x`;")
+}
+
+func TestRestAndDefaultPatternMinified(t *testing.T) {
+	assertMinified(t, `function f(a,...r){}`, `function f(a,...r){}`)
+	assertMinified(t, `let [a,...r]=x;`, `let [a,...r]=x;`)
+	assertMinified(t, `let {a=1}=obj;`, `let {a=1}=obj;`)
+}

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -296,22 +296,17 @@ func TestComputedMemberSequenceMinified(t *testing.T) {
 	assertMinified(t, `a[(b,c)]; a?.[(b,c)];`, `a[(b,c)];a?.[(b,c)];`)
 }
 
-func TestSuperAndClassFeaturesMinified(t *testing.T) {
+func TestClassExtendsAndSuperMinified(t *testing.T) {
 	assertMinified(t,
 		`class A extends B { constructor(){ super(); super.x; } }`,
 		`class A extends B{constructor(){super();super.x;}}`,
 	)
-	assertMinified(t, `class A { x = 1; static y; static { foo(); } }`, `class A{x=1;static y;static{foo();}}`)
-	assertMinified(t,
-		`class A { async m(){ await x; } *g(){ yield 1; } [a+b](){} }`,
-		`class A{async m(){await x;}*g(){yield 1;}[a+b](){}}`,
-	)
 	assertMinified(t, `class A extends (a, b) {}`, `class A extends (a,b){}`)
-	assertMinified(t, `class A { [(a,b)](){} [(a,b)] = 1; }`, `class A{[(a,b)](){}[(a,b)]=1;}`)
 }
 
 func TestGeneratorFunctionsAndObjectMethodsMinified(t *testing.T) {
 	assertMinified(t, `function* g(){ yield 1; }`, `function* g(){yield 1;}`)
+	assertMinified(t, `const g = function*(){ yield 1; };`, `const g=function*(){yield 1;};`)
 	assertMinified(t, `async function* g(){ yield 1; }`, `async function* g(){yield 1;}`)
 	assertMinified(t,
 		`({ m(){ return super.x; }, *g(){ yield 1; } });`,
@@ -326,10 +321,4 @@ func TestTemplateLiteralMinified(t *testing.T) {
 	assertMinified(t, "(function(){})`x`;", "(function(){})`x`;")
 	assertMinified(t, "(class {})`x`;", "(class {})`x`;")
 	assertMinified(t, "({})`x`;", "({})`x`;")
-}
-
-func TestRestAndDefaultPatternMinified(t *testing.T) {
-	assertMinified(t, `function f(a,...r){}`, `function f(a,...r){}`)
-	assertMinified(t, `let [a,...r]=x;`, `let [a,...r]=x;`)
-	assertMinified(t, `let {a=1}=obj;`, `let {a=1}=obj;`)
 }


### PR DESCRIPTION
## Summary

- Emit class `extends` clauses and `super` expressions correctly
- Preserve `function*` / `async function*` markers
- Preserve tagged template tags and raw template literal text

## Details

This builds on the optional-chain/member-base generator fixes already merged on `tagged-unions`.

Fixes include:

- class `extends` output, including parenthesized sequence-expression heritage
- `super` expression output
- named and anonymous generator function output
- tagged template tag output
- raw template element text preservation

The branch was rebuilt against the current `tagged-unions` branch after the upstream AST/generator refactors.

## Testing

```sh
go test ./...
git diff --check
```