### PR TITLE
feat(parser): opt-in ParenthesizedExpression node via PreserveParens

### DIFF
--- a/ast/clone.go
+++ b/ast/clone.go
@@ -209,6 +209,9 @@ func (n *ParameterList) Clone() *ParameterList {
 	}
 	return &ParameterList{List: *n.List.Clone(), Rest: rest, Opening: n.Opening, Closing: n.Closing}
 }
+func (n *ParenthesizedExpression) Clone() *ParenthesizedExpression {
+	return &ParenthesizedExpression{Expression: n.Expression.Clone(), LeftParenthesis: n.LeftParenthesis, RightParenthesis: n.RightParenthesis}
+}
 func (n *PatternKeyValue) Clone() *PatternKeyValue {
 	return &PatternKeyValue{Key: n.Key.Clone(), Value: n.Value.Clone()}
 }
@@ -506,6 +509,10 @@ func (n *Expression) Clone() *Expression {
 	case ExprOptionalChain:
 		c := (*OptionalChain)(n.ptr).Clone()
 		r := NewOptionalChainExpr(c)
+		return &r
+	case ExprParen:
+		c := (*ParenthesizedExpression)(n.ptr).Clone()
+		r := NewParenExpr(c)
 		return &r
 	case ExprPrivDot:
 		c := (*PrivateDotExpression)(n.ptr).Clone()

--- a/ast/expr.go
+++ b/ast/expr.go
@@ -34,6 +34,7 @@ type (
 		ObjectLit      ObjectLiteral
 		Optional       Optional
 		OptionalChain  OptionalChain
+		Paren          ParenthesizedExpression
 		PrivDot        PrivateDotExpression
 		PrivIdentifier PrivateIdentifier
 		RegExpLit      RegExpLiteral
@@ -125,6 +126,18 @@ type (
 		Test       *Expression
 		Consequent *Expression
 		Alternate  *Expression
+	}
+
+	// ParenthesizedExpression is a grouping `( Expression )`. It is only
+	// produced when parsing with [parser.PreserveParens]; by default the
+	// parser discards grouping parentheses and yields the inner expression
+	// directly. Keeping the node makes a parenthesized expression's source
+	// span balanced, since the inner node's own offsets exclude the parens.
+	ParenthesizedExpression struct {
+		Expression *Expression
+
+		LeftParenthesis  Idx
+		RightParenthesis Idx
 	}
 
 	PrivateDotExpression struct {
@@ -310,6 +323,9 @@ func (n *CallExpression) Idx1() Idx { return n.RightParenthesis + 1 }
 
 func (n *ConditionalExpression) Idx0() Idx { return n.Test.Idx0() }
 func (n *ConditionalExpression) Idx1() Idx { return n.Alternate.Idx1() }
+
+func (n *ParenthesizedExpression) Idx0() Idx { return n.LeftParenthesis }
+func (n *ParenthesizedExpression) Idx1() Idx { return n.RightParenthesis + 1 }
 
 func (p *PrivateDotExpression) Idx0() Idx { return p.Left.Idx0() }
 func (p *PrivateDotExpression) Idx1() Idx { return p.Identifier.Idx1() }

--- a/ast/union.go
+++ b/ast/union.go
@@ -267,6 +267,7 @@ const (
 	ExprObjectLit
 	ExprOptional
 	ExprOptionalChain
+	ExprParen
 	ExprPrivDot
 	ExprPrivIdentifier
 	ExprRegExpLit
@@ -329,6 +330,8 @@ func (k ExprKind) String() string {
 		return "ExprOptional"
 	case ExprOptionalChain:
 		return "ExprOptionalChain"
+	case ExprParen:
+		return "ExprParen"
 	case ExprPrivDot:
 		return "ExprPrivDot"
 	case ExprPrivIdentifier:
@@ -844,6 +847,28 @@ func (n *Expression) IsOptionalChain() bool {
 	return n.kind == ExprOptionalChain
 }
 
+func NewParenExpr(n *ParenthesizedExpression) Expression {
+	return Expression{kind: ExprParen, ptr: unsafe.Pointer(n)}
+}
+
+func (n *Expression) Paren() (*ParenthesizedExpression, bool) {
+	if n.kind == ExprParen {
+		return (*ParenthesizedExpression)(n.ptr), true
+	}
+	return nil, false
+}
+
+func (n *Expression) MustParen() *ParenthesizedExpression {
+	if n.kind != ExprParen {
+		panic("unexpected kind: " + n.kind.String())
+	}
+	return (*ParenthesizedExpression)(n.ptr)
+}
+
+func (n *Expression) IsParen() bool {
+	return n.kind == ExprParen
+}
+
 func NewPrivDotExpr(n *PrivateDotExpression) Expression {
 	return Expression{kind: ExprPrivDot, ptr: unsafe.Pointer(n)}
 }
@@ -1154,6 +1179,8 @@ func (n *Expression) Idx0() Idx {
 		return (*Optional)(n.ptr).Idx0()
 	case ExprOptionalChain:
 		return (*OptionalChain)(n.ptr).Idx0()
+	case ExprParen:
+		return (*ParenthesizedExpression)(n.ptr).Idx0()
 	case ExprPrivDot:
 		return (*PrivateDotExpression)(n.ptr).Idx0()
 	case ExprPrivIdentifier:
@@ -1228,6 +1255,8 @@ func (n *Expression) Idx1() Idx {
 		return (*Optional)(n.ptr).Idx1()
 	case ExprOptionalChain:
 		return (*OptionalChain)(n.ptr).Idx1()
+	case ExprParen:
+		return (*ParenthesizedExpression)(n.ptr).Idx1()
 	case ExprPrivDot:
 		return (*PrivateDotExpression)(n.ptr).Idx1()
 	case ExprPrivIdentifier:
@@ -1305,6 +1334,8 @@ func (n *Expression) Unwrap() VisitableNode {
 		return (*Optional)(n.ptr)
 	case ExprOptionalChain:
 		return (*OptionalChain)(n.ptr)
+	case ExprParen:
+		return (*ParenthesizedExpression)(n.ptr)
 	case ExprPrivDot:
 		return (*PrivateDotExpression)(n.ptr)
 	case ExprPrivIdentifier:

--- a/ast/visit.go
+++ b/ast/visit.go
@@ -56,6 +56,7 @@ type Visitor interface {
 	VisitOptional(n *Optional)
 	VisitOptionalChain(n *OptionalChain)
 	VisitParameterList(n *ParameterList)
+	VisitParenthesizedExpression(n *ParenthesizedExpression)
 	VisitPattern(n *Pattern)
 	VisitPatternKeyValue(n *PatternKeyValue)
 	VisitPatternProperties(n *PatternProperties)
@@ -263,6 +264,9 @@ func (nv *NoopVisitor) VisitOptionalChain(n *OptionalChain) {
 	n.VisitChildrenWith(nv.V)
 }
 func (nv *NoopVisitor) VisitParameterList(n *ParameterList) {
+	n.VisitChildrenWith(nv.V)
+}
+func (nv *NoopVisitor) VisitParenthesizedExpression(n *ParenthesizedExpression) {
 	n.VisitChildrenWith(nv.V)
 }
 func (nv *NoopVisitor) VisitPattern(n *Pattern) {
@@ -732,6 +736,12 @@ func (n *ParameterList) VisitChildrenWith(v Visitor) {
 		n.Rest.VisitWith(v)
 	}
 }
+func (n *ParenthesizedExpression) VisitWith(v Visitor) {
+	v.VisitParenthesizedExpression(n)
+}
+func (n *ParenthesizedExpression) VisitChildrenWith(v Visitor) {
+	n.Expression.VisitWith(v)
+}
 func (n *PatternKeyValue) VisitWith(v Visitor) {
 	v.VisitPatternKeyValue(n)
 }
@@ -1077,6 +1087,8 @@ func (n *Expression) VisitChildrenWith(v Visitor) {
 		(*Optional)(n.ptr).VisitWith(v)
 	case ExprOptionalChain:
 		(*OptionalChain)(n.ptr).VisitWith(v)
+	case ExprParen:
+		(*ParenthesizedExpression)(n.ptr).VisitWith(v)
 	case ExprPrivDot:
 		(*PrivateDotExpression)(n.ptr).VisitWith(v)
 	case ExprPrivIdentifier:

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -147,6 +147,12 @@ func (g *GenVisitor) VisitAssignExpression(n *ast.AssignExpression) {
 	}
 }
 
+func (g *GenVisitor) VisitParenthesizedExpression(n *ast.ParenthesizedExpression) {
+	g.writeByte('(')
+	g.genExpr(n.Expression, ast.PrecedenceLowest, 0)
+	g.writeByte(')')
+}
+
 func (g *GenVisitor) VisitConditionalExpression(n *ast.ConditionalExpression) {
 	ctx := g.ctx
 	wrap := g.prec > ast.PrecedenceConditional

--- a/parser/alloc.go
+++ b/parser/alloc.go
@@ -39,6 +39,7 @@ type nodeAllocator struct {
 	updateExp arena[ast.UpdateExpression]
 	assignExp arena[ast.AssignExpression]
 	condExpr  arena[ast.ConditionalExpression]
+	parenExpr arena[ast.ParenthesizedExpression]
 	seqExpr   arena[ast.SequenceExpression]
 	memberExp arena[ast.MemberExpression]
 	memberPrp arena[ast.MemberProperty]
@@ -155,6 +156,7 @@ func newNodeAllocator() nodeAllocator {
 		updateExp: newArena[ast.UpdateExpression](64),
 		assignExp: newArena[ast.AssignExpression](64),
 		condExpr:  newArena[ast.ConditionalExpression](64),
+		parenExpr: newArena[ast.ParenthesizedExpression](32),
 		seqExpr:   newArena[ast.SequenceExpression](32),
 		memberExp: newArena[ast.MemberExpression](256),
 		memberPrp: newArena[ast.MemberProperty](256),
@@ -438,6 +440,12 @@ func (a *nodeAllocator) ComputedProperty(left ast.Idx, expr *ast.Expression, rig
 func (a *nodeAllocator) CallExpression(callee *ast.Expression, lp ast.Idx, args ast.Expressions, rp ast.Idx) *ast.CallExpression {
 	n := a.callExpr.make()
 	*n = ast.CallExpression{Callee: callee, LeftParenthesis: lp, ArgumentList: args, RightParenthesis: rp}
+	return n
+}
+
+func (a *nodeAllocator) ParenthesizedExpression(lp ast.Idx, expr *ast.Expression, rp ast.Idx) *ast.ParenthesizedExpression {
+	n := a.parenExpr.make()
+	*n = ast.ParenthesizedExpression{Expression: expr, LeftParenthesis: lp, RightParenthesis: rp}
 	return n
 }
 

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -172,11 +172,14 @@ func (p *parser) parseParenthesisedExpression() ast.Expression {
 			}
 		}
 	}
-	p.expect(token.RightParenthesis)
+	closing := p.expect(token.RightParenthesis)
 	n := len(p.exprBuf) - mark
 	if n == 1 && p.errors == nil {
 		result := p.exprBuf[mark]
 		p.exprBuf = p.exprBuf[:mark]
+		if p.options.preserveParens {
+			return ast.NewParenExpr(p.alloc.ParenthesizedExpression(opening, p.alloc.Expression(result), closing))
+		}
 		return result
 	}
 	if n == 0 {

--- a/parser/options.go
+++ b/parser/options.go
@@ -1,0 +1,22 @@
+package parser
+
+// parseOptions holds tunable parser behavior. Its zero value is the default
+// behavior, so passing no [Option] to [Parse] leaves parsing unchanged.
+type parseOptions struct {
+	preserveParens bool
+}
+
+// Option customizes parsing behavior. Pass options to [Parse] or [ParseBytes].
+type Option func(*parseOptions)
+
+// PreserveParens makes the parser keep grouping parentheses as explicit
+// [ast.ParenthesizedExpression] nodes instead of discarding them.
+//
+// By default `(expr)` parses to the inner expression directly, whose byte
+// offsets exclude the parentheses; a parent node spanning such a child can
+// therefore report a source range with an unbalanced parenthesis. Opting in
+// keeps the parentheses in the tree so every node's [ast.Node.Idx0]/Idx1
+// range slices to balanced source.
+func PreserveParens() Option {
+	return func(o *parseOptions) { o.preserveParens = true }
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -26,6 +26,8 @@ type parser struct {
 
 	alloc nodeAllocator
 
+	options parseOptions
+
 	// Scratch buffers used as a stack for building Expression/Statement
 	// slices without per-call heap allocations. Each builder saves
 	// len(buf) as a mark, appends elements, copies the subslice to the
@@ -64,6 +66,7 @@ func getParser(src string) *parser {
 func putParser(p *parser) {
 	p.str = ""
 	p.alloc = nodeAllocator{}
+	p.options = parseOptions{}
 	p.scanner = scanner.Scanner{}
 	p.scope = nil
 	p.errors = nil
@@ -81,12 +84,16 @@ func putParser(p *parser) {
 
 // Parse parses src as an ECMAScript script and returns the program AST.
 // Errors are accumulated; on a non-nil error the returned [*ast.Program]
-// may still be partially populated.
+// may still be partially populated. Behavior can be tuned with [Option]
+// values such as [PreserveParens]; with none, parsing uses its defaults.
 //
 // To recover byte positions from errors use [errors.As] against
 // [*Error] or [scanner.Error], or the shared [ast.Positioned] interface.
-func Parse(src string) (*ast.Program, error) {
+func Parse(src string, opts ...Option) (*ast.Program, error) {
 	p := getParser(src)
+	for _, opt := range opts {
+		opt(&p.options)
+	}
 	program, err := p.parse()
 	putParser(p)
 	return program, err
@@ -96,8 +103,8 @@ func Parse(src string) (*ast.Program, error) {
 // contents must remain valid for the lifetime of the returned AST: the
 // parser stores no-copy references into src for identifier and literal
 // names.
-func ParseBytes(src []byte) (*ast.Program, error) {
-	return Parse(unsafe.String(unsafe.SliceData(src), len(src)))
+func ParseBytes(src []byte, opts ...Option) (*ast.Program, error) {
+	return Parse(unsafe.String(unsafe.SliceData(src), len(src)), opts...)
 }
 
 // parse ...

--- a/parser/preserve_parens_test.go
+++ b/parser/preserve_parens_test.go
@@ -1,0 +1,187 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/t14raptor/go-fast/ast"
+	"github.com/t14raptor/go-fast/generator"
+	"github.com/t14raptor/go-fast/parser"
+	"github.com/t14raptor/go-fast/resolver"
+)
+
+type identCollector struct {
+	ast.NoopVisitor
+	name  string
+	nodes []*ast.Identifier
+}
+
+func (c *identCollector) VisitIdentifier(n *ast.Identifier) {
+	if n.Name == c.name {
+		c.nodes = append(c.nodes, n)
+	}
+}
+
+func collectIdents(prog *ast.Program, name string) []*ast.Identifier {
+	c := &identCollector{name: name}
+	c.V = c
+	prog.VisitChildrenWith(c)
+	return c.nodes
+}
+
+// parenCollector gathers every ParenthesizedExpression in a tree.
+type parenCollector struct {
+	ast.NoopVisitor
+	nodes []*ast.ParenthesizedExpression
+}
+
+func (c *parenCollector) VisitParenthesizedExpression(n *ast.ParenthesizedExpression) {
+	c.nodes = append(c.nodes, n)
+	n.VisitChildrenWith(c.V)
+}
+
+func collectParens(prog *ast.Program) []*ast.ParenthesizedExpression {
+	c := &parenCollector{}
+	c.V = c
+	prog.VisitChildrenWith(c)
+	return c.nodes
+}
+
+func balanced(s string) bool {
+	depth := 0
+	for _, r := range s {
+		switch r {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		}
+		if depth < 0 {
+			return false
+		}
+	}
+	return depth == 0
+}
+
+// By default grouping parentheses are discarded and the AST shape is unchanged:
+// no ParenthesizedExpression node ever appears.
+func TestPreserveParensDefaultOff(t *testing.T) {
+	for _, src := range []string{`x = (a) || b;`, `y = a || (b);`, `z = ((a));`, `w = f((a + b));`} {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("parse %q: %v", src, err)
+		}
+		if got := collectParens(prog); len(got) != 0 {
+			t.Errorf("%q: expected no ParenthesizedExpression by default, got %d", src, len(got))
+		}
+	}
+}
+
+// With PreserveParens, a parenthesized expression becomes a node whose
+// Idx0/Idx1 span the parentheses, so the source slice is always balanced —
+// unlike the inner node's own offsets, which stop inside the parentheses.
+func TestPreserveParensBalancedSpan(t *testing.T) {
+	cases := []struct {
+		src  string
+		want string // the exact parenthesized source the node should cover
+	}{
+		{`a || (b);`, `(b)`},
+		{`(a) || b;`, `(a)`},
+		{`a || (b || c);`, `(b || c)`},
+		{`p["k"] || (a + b);`, `(a + b)`},
+	}
+	for _, tc := range cases {
+		prog, err := parser.Parse(tc.src, parser.PreserveParens())
+		if err != nil {
+			t.Fatalf("parse %q: %v", tc.src, err)
+		}
+		parens := collectParens(prog)
+		if len(parens) != 1 {
+			t.Fatalf("%q: want 1 paren node, got %d", tc.src, len(parens))
+		}
+		n := parens[0]
+		got := tc.src[n.Idx0():n.Idx1()]
+		if got != tc.want {
+			t.Errorf("%q: node span = %q, want %q", tc.src, got, tc.want)
+		}
+		if !balanced(got) {
+			t.Errorf("%q: node span %q is not balanced", tc.src, got)
+		}
+	}
+}
+
+// Nested grouping nests the node: ((a)) -> Paren(Paren(Identifier)).
+func TestPreserveParensNested(t *testing.T) {
+	prog, err := parser.Parse(`x = ((a));`, parser.PreserveParens())
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	parens := collectParens(prog)
+	if len(parens) != 2 {
+		t.Fatalf("want 2 nested paren nodes, got %d", len(parens))
+	}
+	inner, ok := parens[1].Expression.Identifier()
+	if !ok {
+		t.Fatalf("innermost paren should wrap an identifier, got kind %v", parens[1].Expression.Kind())
+	}
+	if inner.Name != "a" {
+		t.Errorf("innermost identifier = %q, want %q", inner.Name, "a")
+	}
+}
+
+// Only the single-expression form is wrapped. A comma sequence stays a
+// SequenceExpression and empty parens stay an error node — no Paren wrapper.
+func TestPreserveParensSequenceUnchanged(t *testing.T) {
+	prog, err := parser.Parse(`x = (a, b);`, parser.PreserveParens())
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := collectParens(prog); len(got) != 0 {
+		t.Errorf("comma sequence should not be wrapped, got %d paren nodes", len(got))
+	}
+}
+
+// The generator round-trips the node, re-emitting the parentheses it stands
+// for. Redundant parentheses that the default path would drop are preserved.
+func TestPreserveParensRoundTrip(t *testing.T) {
+	src := `x = (a) + b;`
+
+	def, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse default: %v", err)
+	}
+	if got := generator.Generate(def); got != "x = a + b;\n" {
+		t.Errorf("default generate = %q, want %q", got, "x = a + b;\n")
+	}
+
+	kept, err := parser.Parse(src, parser.PreserveParens())
+	if err != nil {
+		t.Fatalf("parse preserve: %v", err)
+	}
+	if got := generator.Generate(kept); got != "x = (a) + b;\n" {
+		t.Errorf("preserve generate = %q, want %q", got, "x = (a) + b;\n")
+	}
+}
+
+// The resolver descends through the node, so a reference wrapped in
+// parentheses resolves to the same binding as an unwrapped one.
+func TestPreserveParensResolvesThrough(t *testing.T) {
+	prog, err := parser.Parse(`function f() { var a = 1; return a + (a); }`, parser.PreserveParens())
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	resolver.Resolve(prog)
+
+	idents := collectIdents(prog, "a")
+	if len(idents) != 3 { // declarator + two references
+		t.Fatalf("want 3 occurrences of 'a', got %d", len(idents))
+	}
+	ctx := idents[0].ScopeContext
+	if ctx == ast.UnresolvedContext {
+		t.Fatal("declaration of 'a' left unresolved")
+	}
+	for i, id := range idents {
+		if id.ScopeContext != ctx {
+			t.Errorf("occurrence %d resolved to a different binding than the declaration", i)
+		}
+	}
+}


### PR DESCRIPTION
Adds an opt-in `ParenthesizedExpression` node so `(expr)` can be retained instead of discarded.

By default the parser drops grouping parens and returns the inner expression, whose offsets exclude the parens — so a parent spanning it slices to unbalanced source (`a || (b)` → `a || (b`). SWC (the stated model) keeps a paren node for this.

- New `parser.PreserveParens()` option; `Parse`/`ParseBytes` gain a source-compatible variadic `...Option`. **Off by default** — AST shape and existing callers unchanged.
- When on, the node's `Idx0/Idx1` span the parens (balanced); generator round-trips it; `NoopVisitor`/resolver descend through it transparently.
- Only the single-expression form is wrapped; comma sequences and empty parens are unchanged.

Tests in `parser/preserve_parens_test.go`; regenerated `union/visit/clone` committed. `go test ./...` and `go vet ./...` green.
