### PR TITLE
fix(scanner): always advance so Next reaches Eof

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ go get github.com/t14raptor/go-fast
 ```
 
 ## Docs
-[Documentation](https://yoghurtbot-io.gitbook.io/go-fast)
+[Documentation](https://gofast.disasm.dev)
 
 ## Credits
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/t14raptor/go-fast/ast"
 	"github.com/t14raptor/go-fast/generator"
@@ -2106,4 +2107,65 @@ func TestYieldExpressionAST(t *testing.T) {
 	if !y2.Delegate {
 		t.Error("yield* should be delegate")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Scanner progress
+// ---------------------------------------------------------------------------
+
+// parseWithinTimeout fails instead of hanging the suite when the scanner stops
+// making progress.
+func parseWithinTimeout(t *testing.T, code string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = parser.Parse(code)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("Parse(%q) did not terminate", code)
+	}
+}
+
+// The scanner dispatch table enumerates byte cases, and bytes it did not list
+// left the source position untouched, so Next never reached Eof and any loop
+// scanning to Eof ran forever. Invalid UTF-8 leading bytes reached that state
+// directly; a malformed numeric literal reached it indirectly, because the
+// error path advances a single byte and can leave the scanner in the middle of
+// a multi-byte rune, positioned on a continuation byte.
+func TestScannerAlwaysAdvances(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		code string
+	}{
+		{name: "invalid leading byte", code: "\x89"},
+		{name: "binary body", code: "\x89PNG\r\n\x1a\n"},
+		{name: "latin-1 identifier", code: "var caf\xe9 = 1;"},
+		{name: "unpaired continuation byte", code: "var a = 1;\x80"},
+		{name: "hex literal before a rune", code: "x = 0xé"},
+		{name: "exponent before a rune", code: "x = .1e\U0001F600"},
+		{name: "regex literal before a bad number", code: "x = /'/ + 0xé"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			parseWithinTimeout(t, test.code)
+		})
+	}
+}
+
+// Any single byte must terminate wherever it appears, including inside the
+// numeric literal error path.
+func TestScannerAdvancesOnEveryByte(t *testing.T) {
+	for b := 0; b <= 0xFF; b++ {
+		raw := string([]byte{byte(b)})
+		for _, code := range []string{raw, "var a = 1;" + raw, "x = 0x" + raw} {
+			parseWithinTimeout(t, code)
+		}
+	}
+}
+
+// Valid sources, including non-ASCII ones, must be unaffected.
+func TestScannerAcceptsNonASCIISources(t *testing.T) {
+	assertRoundTrip(t, "var café = '☕';", "var café = '☕';")
 }

--- a/parser/scanner/table.go
+++ b/parser/scanner/table.go
@@ -550,6 +550,20 @@ func (s *Scanner) Next() {
 				s.error(invalidCharacter(c, start, s.src.Offset()))
 				s.Token.Kind = token.Undetermined
 			}
+
+		// ---- Non-ASCII: invalid UTF-8 leading and continuation bytes ----
+		//
+		// Every remaining byte lands here: 0x80-0xC1 and 0xF5-0xFF. Without
+		// this arm the switch matched nothing, the source position stayed put,
+		// and the loop below broke out with Idx1 == Idx0, so Next never
+		// reached Eof and callers scanning to Eof spun forever. Consume a
+		// single byte rather than a rune: these bytes do not begin a valid
+		// sequence, and ConsumeRune would advance by the width of
+		// utf8.RuneError and could run past the end of the source.
+		default:
+			s.ConsumeByte()
+			s.error(invalidCharacter(rune(b), s.Token.Idx0, s.src.Offset()))
+			s.Token.Kind = token.Undetermined
 		}
 		break
 	}


### PR DESCRIPTION
`Scanner.Next` can return the same zero-width token forever, so any loop that scans to `token.Eof` never terminates.

```go
_, _ = parser.Parse("\x89PNG\r\n\x1a\n") // never returns
_, _ = parser.Parse("x = 0xé")           // never returns
```

## Cause

The dispatch table in `Next` enumerates byte cases with no `default:` arm. A byte it does not list matches nothing, so the source position is never advanced and control reaches the trailing `break` with `Idx1 == Idx0`. The next call starts from the same offset and repeats.

77 byte values reach this directly: `0x80`–`0xC1` and `0xF5`–`0xFF`. Any body that is not valid UTF-8 will do — PNG or gzip magic, a font, a Latin-1/CP1252 bundle.

Valid UTF-8 reaches it indirectly. `unexpectedErr` advances exactly one byte, which can land in the middle of a multi-byte rune and leave the scanner on a continuation byte. So a malformed numeric literal followed by a non-ASCII rune hangs as well:

```go
parser.Parse("x = 0xé")         // 0x, then the first byte of é consumed, then 0xa9
parser.Parse("x = .1e😀")
parser.Parse("x = /'/ + 0xé")   // valid UTF-8, plausible source, still hangs
```

That last one is why this is worth fixing in the scanner rather than in callers: it is ordinary-looking JavaScript, so a caller cannot filter for it. `ParseFile`/`Parse` take no `context`, and a non-advancing loop is not a panic, so a caller cannot bound it with `recover` either — the only options left are abandoning a goroutine that then spins for the life of the process, or this.

## Fix

One `default:` arm, mirroring the existing invalid-ASCII case.

It consumes a single **byte** rather than a rune deliberately. These bytes do not begin a valid sequence, and `Source.NextRune` advances by `utf8.RuneLen(chr)`, which for the replacement character is 3 — that would skip up to two following valid characters and could move `pos` past `len`, which in turn would make `Token.Idx1` exceed the source length and break the unsafe slicing in `Token.String`. Consuming one byte cannot do either, since the switch has already established `pos < len`.

## Verification

- All 256 byte values now terminate in three positions: at the start of a source, after valid code, and inside the numeric literal error path.
- The existing suite passes unchanged (`go test ./...`, `go vet ./...`, `gofmt` clean).
- Added `TestScannerAlwaysAdvances`, `TestScannerAdvancesOnEveryByte`, and `TestScannerAcceptsNonASCIISources` in `parser/parser_test.go`. They parse on a goroutine with a timeout so a regression fails the suite instead of hanging CI. Without the fix, 7 of these cases fail with `did not terminate`.

## Two adjacent things I did not touch, in case they are of interest

1. `Source.NextRune` uses `s.pos += ast.Idx(utf8.RuneLen(chr))`, so on invalid input it advances 3 bytes for a 1-byte problem. Termination no longer depends on it, but it can over-consume.
2. `unexpectedErr`'s bare `pos++` is what leaves the scanner mid-rune. Advancing a whole rune there would make the reported error range more accurate, though the `default:` arm now makes it non-fatal.

Happy to adjust the shape of the fix or move the tests into a `parser/scanner` package test if you would prefer that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)