### PR TITLE
fix(parser): reject invalid untagged template escapes

### DIFF
--- a/parser/expression.go
+++ b/parser/expression.go
@@ -63,7 +63,7 @@ func (p *parser) parsePrimaryExpression() ast.Expression {
 	case token.LeftParenthesis:
 		return p.parseParenthesisedExpression()
 	case token.NoSubstitutionTemplate, token.TemplateHead:
-		return ast.NewTmplLitExpr(p.parseTemplateLiteral())
+		return ast.NewTmplLitExpr(p.parseTemplateLiteral(false))
 	case token.This:
 		p.next()
 		return ast.NewThisExpr(p.alloc.ThisExpression(idx))
@@ -564,7 +564,7 @@ func (p *parser) parseArrayLiteral() *ast.ArrayLiteral {
 	return p.alloc.ArrayLiteral(idx0, idx1, p.finishExprBuf(mark))
 }
 
-func (p *parser) parseTemplateLiteral() *ast.TemplateLiteral {
+func (p *parser) parseTemplateLiteral(tagged bool) *ast.TemplateLiteral {
 	res := p.alloc.TemplateLiteral(p.currentOffset())
 	mark := len(p.exprBuf)
 
@@ -573,6 +573,9 @@ func (p *parser) parseTemplateLiteral() *ast.TemplateLiteral {
 		literal := p.scanner.Token.TemplateLiteral(p.scanner)
 		parsed := p.scanner.Token.TemplateParsed(p.scanner)
 		kind := p.currentKind()
+		if !tagged && p.scanner.Token.HasInvalidEscape {
+			p.errorAt(start, p.scanner.Token.Idx1, "Invalid escape sequence in untagged template literal")
+		}
 
 		res.Elements = append(res.Elements, ast.TemplateElement{
 			Idx:     start,
@@ -601,7 +604,7 @@ func (p *parser) parseTemplateLiteral() *ast.TemplateLiteral {
 }
 
 func (p *parser) parseTaggedTemplateLiteral(tag *ast.Expression) *ast.TemplateLiteral {
-	l := p.parseTemplateLiteral()
+	l := p.parseTemplateLiteral(true)
 	l.Tag = tag
 	return l
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -410,6 +410,78 @@ func TestTaggedTemplateLiteralAST(t *testing.T) {
 	}
 }
 
+func TestTemplateLiteralRejectsInvalidUntaggedEscapes(t *testing.T) {
+	tests := []string{
+		"`\\8`",
+		"`\\9`",
+		"`\\1`",
+		"`\\01`",
+		"`\\xG`",
+		"`\\uZZZZ`",
+		"`\\u{110000}`",
+		"`\\8${value}`",
+		"`${value}\\8${other}`",
+		"`${value}\\8`",
+	}
+
+	for _, code := range tests {
+		t.Run(code, func(t *testing.T) {
+			_, err := parser.Parse(code)
+			if err == nil {
+				t.Fatal("expected parse error")
+			}
+			if !strings.Contains(err.Error(), "Invalid escape sequence in untagged template literal") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestTemplateLiteralAcceptsInvalidTaggedEscapes(t *testing.T) {
+	tests := []string{
+		"tag`\\8`",
+		"tag`\\9`",
+		"tag`\\1`",
+		"tag`\\01`",
+		"tag`\\xG`",
+		"tag`\\uZZZZ`",
+		"tag`\\u{110000}`",
+		"tag`\\uD834\\uZZZZ`",
+		"tag`\\8${value}`",
+		"tag`${value}\\8${other}`",
+		"tag`${value}\\8`",
+	}
+
+	for _, code := range tests {
+		t.Run(code, func(t *testing.T) {
+			mustParse(t, code)
+		})
+	}
+}
+
+func TestUnicodeSurrogateEscapeLookahead(t *testing.T) {
+	tests := []string{
+		"'\\uD834\\uDF06'",
+		"'\\uD834\\u0041'",
+		"'\\uDC00\\u0041'",
+		"`\\uD834\\uDF06`",
+		"`\\uD834\\u0041`",
+		"`\\uDC00\\u0041`",
+		"tag`\\uD834\\u0041`",
+	}
+
+	for _, code := range tests {
+		t.Run(code, func(t *testing.T) {
+			mustParse(t, code)
+		})
+	}
+
+	_, err := parser.Parse("`\\uD834\\uZZZZ`")
+	if err == nil {
+		t.Fatal("expected malformed second escape to fail")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // RegExp literal — pattern and flags preserved
 // ---------------------------------------------------------------------------

--- a/parser/scanner/scanner.go
+++ b/parser/scanner/scanner.go
@@ -103,6 +103,8 @@ func (s *Scanner) AdvanceIfByteEquals(b byte) bool {
 }
 
 func (s *Scanner) NextTemplatePart() {
+	s.Token.HasEscape = false
+	s.Token.HasInvalidEscape = false
 	s.Token.Idx0 = s.src.Offset() - 1
 	s.Token.Kind = s.ReadTemplateLiteral(token.TemplateMiddle, token.TemplateTail)
 	s.Token.Idx1 = s.src.Offset()

--- a/parser/scanner/table.go
+++ b/parser/scanner/table.go
@@ -9,6 +9,7 @@ import (
 
 func (s *Scanner) Next() {
 	s.Token.HasEscape = false
+	s.Token.HasInvalidEscape = false
 	s.Token.OnNewLine = false
 
 	for {

--- a/parser/scanner/template.go
+++ b/parser/scanner/template.go
@@ -128,6 +128,7 @@ func (s *Scanner) templateLiteralEscaped(str *strings.Builder, chunkStart ast.Id
 			str.WriteString(s.src.FromPositionToCurrent(chunkStart))
 			s.EscapedStr = str.String()
 			s.Token.HasEscape = true
+			s.Token.HasInvalidEscape = !*isValid
 			return token.Undetermined
 		}
 
@@ -146,6 +147,7 @@ func (s *Scanner) templateLiteralEscaped(str *strings.Builder, chunkStart ast.Id
 				s.ConsumeByte() // {
 				s.EscapedStr = str.String()
 				s.Token.HasEscape = true
+				s.Token.HasInvalidEscape = !*isValid
 				return ret // = sub
 			}
 			// Not `${`, continue scanning
@@ -158,6 +160,7 @@ func (s *Scanner) templateLiteralEscaped(str *strings.Builder, chunkStart ast.Id
 			ret = tail
 			s.EscapedStr = str.String()
 			s.Token.HasEscape = true
+			s.Token.HasInvalidEscape = !*isValid
 			return ret
 
 		case '\r':

--- a/parser/scanner/token.go
+++ b/parser/scanner/token.go
@@ -10,6 +10,8 @@ type Token struct {
 
 	OnNewLine bool
 	HasEscape bool
+	// HasInvalidEscape marks a template token containing a NotEscapeSequence.
+	HasInvalidEscape bool
 
 	Idx0, Idx1 ast.Idx // 8 bytes
 }

--- a/parser/scanner/unicode.go
+++ b/parser/scanner/unicode.go
@@ -135,20 +135,30 @@ func (s *Scanner) codePoint() rune {
 }
 
 func (s *Scanner) surrogatePair() rune {
+	const (
+		minHigh = 0xD800
+		maxHigh = 0xDBFF
+		minLow  = 0xDC00
+		maxLow  = 0xDFFF
+	)
+
 	high := s.hexFourDigits()
-	if !utf16.IsSurrogate(high) {
-		return high
-	} else if b, ok := s.src.PeekTwoBytes(); !ok || b != [2]byte{'\\', 'u'} {
+	if high < minHigh || high > maxHigh {
 		return high
 	}
 
+	if b, ok := s.src.PeekTwoBytes(); !ok || b != [2]byte{'\\', 'u'} {
+		return high
+	}
+
+	beforeSecond := s.src.Offset()
 	s.ConsumeByte()
 	s.ConsumeByte()
 
 	low := s.hexFourDigits()
-	if !utf16.IsSurrogate(low) {
-		// invalid
-		return -1
+	if low < minLow || low > maxLow {
+		s.src.SetPosition(beforeSecond)
+		return high
 	}
 
 	return utf16.DecodeRune(high, low)


### PR DESCRIPTION
Reject invalid escapes in untagged templates while keeping them valid in tagged templates.

Also fixes Unicode escapes that do not form a valid surrogate pair.